### PR TITLE
feat: full-prose walkthroughs with embedded milestone checkpoints

### DIFF
--- a/.github/copilot/skills/walkthrough-ingest.md
+++ b/.github/copilot/skills/walkthrough-ingest.md
@@ -1,7 +1,7 @@
 # Walkthrough Ingestion Skill
 
 ## Description
-Converts any online game walkthrough into the standardized walkthrough JSON format used by the Walkthrough Checklist App. The output is a valid JSON file committed to the `/walkthroughs/` directory.
+Converts any online game walkthrough into the standardized walkthrough JSON format used by the Walkthrough Checklist App. The output preserves the **full original prose** with embedded milestone checkpoints plus granular step checklists. The result is committed to the `/walkthroughs/` directory.
 
 ## When to use
 Use this skill when you want to add a new walkthrough to the app. Provide either:
@@ -48,7 +48,32 @@ Do NOT just output a code block — actually create the file and commit it.
 
 3. **Break content into sections** that map to major game areas, chapters, or phases. Each section needs a unique slug `id` and a human-readable `title`.
 
-4. **Classify each step** using the correct `type` and understand its icon in the app:
+4. **Preserve full walkthrough prose in the `content` field.** Each section MUST have a `content` field containing the full original walkthrough text in **Markdown**. Do NOT abbreviate or summarize. Preserve:
+   - Detailed descriptions of areas, enemies, and environment
+   - Strategy tips, build advice, and combat guidance
+   - Story context and lore notes
+   - Navigation directions (go left, take the second door, etc.)
+   - NPC dialogue triggers and quest conditions
+
+   Use Markdown formatting: `**bold**` for item/boss/location names, `>` for tips/quotes, `##` / `###` for sub-headings within a section, `-` for lists.
+
+5. **Embed checkpoint markers in the content.** At major milestones within the prose, insert an HTML comment marker:
+   ```
+   <!-- checkpoint: <id> | <label> -->
+   ```
+   - `<id>` is a unique slug (lowercase, hyphens, e.g. `asylum-demon-defeated`)
+   - `<label>` is the human-readable milestone text (e.g. `Defeated the Asylum Demon`)
+   - Place checkpoints after boss defeats, area transitions, major item acquisitions, and quest completions
+   - Aim for 3-8 checkpoints per section depending on length
+
+6. **List all checkpoints in the `checkpoints` array.** Every `<!-- checkpoint: id | label -->` marker in `content` MUST have a matching entry in the section's `checkpoints` array:
+   ```json
+   "checkpoints": [
+     { "id": "asylum-demon-defeated", "label": "Defeated the Asylum Demon" }
+   ]
+   ```
+
+7. **Also generate granular `steps` for detailed tracking.** The `steps` array provides a concise checklist alongside the prose. Classify each step using the correct `type`:
 
    | Icon | Type | Meaning |
    |------|------|---------|
@@ -60,26 +85,29 @@ Do NOT just output a code block — actually create the file and commit it.
 
    These icons are the canonical legend displayed in the webapp. Use only these five `type` values — no others are valid.
 
-5. **Keep step text concise.** Each step should be one action or one piece of information. Split long paragraphs into multiple steps. Use **bold** for item names, boss names, and key locations.
+8. **Keep step text concise.** Each step should be one action or one piece of information. Split long paragraphs into multiple steps. Use **bold** for item names, boss names, and key locations.
 
-6. **Add a `note` field** when the original walkthrough has important supplemental info for that step (tips, warnings, quantities, coordinates). Keep notes short.
+9. **Add a `note` field** when the original walkthrough has important supplemental info for that step (tips, warnings, quantities, coordinates). Keep notes short.
 
-7. **Suggested file path** format: `walkthroughs/<game-slug>/<walkthrough-slug>.json`
-   - Example: `walkthroughs/elden-ring/main-walkthrough.json`
+10. **Suggested file path** format: `walkthroughs/<game-slug>/<walkthrough-slug>.json`
+    - Example: `walkthroughs/elden-ring/main-walkthrough.json`
 
-8. **`created_at`** should be today's date in `YYYY-MM-DD` format.
+11. **`created_at`** should be today's date in `YYYY-MM-DD` format.
 
-9. **Validate your output** against the schema before committing:
-   - All required fields present (`id`, `game`, `title`, `author`, `source_url`, `attribution`, `created_at`, `sections`)
-   - All `id` fields match pattern: `^[a-z0-9]+(-[a-z0-9]+)*$`
-   - `source_url` is a valid URI
-   - `sections` array has at least one entry
-   - Each `steps` array has at least one entry
-   - Step `type` is one of: `step`, `note`, `warning`, `collectible`, `boss`
-   - `$schema` is set to the correct relative path (e.g., `../walkthrough.schema.json` or `../../walkthrough.schema.json` depending on depth)
+12. **Validate your output** against the schema before committing:
+    - All required fields present (`id`, `game`, `title`, `author`, `source_url`, `attribution`, `created_at`, `sections`)
+    - All `id` fields match pattern: `^[a-z0-9]+(-[a-z0-9]+)*$`
+    - `source_url` is a valid URI
+    - `sections` array has at least one entry
+    - Each section has either `content` or `steps` (or both)
+    - Every checkpoint `id` in the `checkpoints` array must appear in a `<!-- checkpoint: id | label -->` marker in `content`
+    - Step `type` is one of: `step`, `note`, `warning`, `collectible`, `boss`
+    - `$schema` is set to the correct relative path (e.g., `../walkthrough.schema.json`)
 
-10. **Be thorough.** A good walkthrough has:
-    - At least 50+ steps for a full-length RPG
+13. **Be thorough.** A good walkthrough has:
+    - Rich prose `content` that reads like the original walkthrough
+    - 3-8 milestone checkpoints per section
+    - Granular `steps` array with 50+ steps for a full-length RPG
     - Boss fights called out with HP and strategy tips when available
     - Collectibles and missables clearly marked
     - Warnings before point-of-no-return moments
@@ -104,17 +132,23 @@ Do NOT just output a code block — actually create the file and commit it.
     {
       "id": "chapter-1",
       "title": "Chapter 1: The Beginning",
+      "content": "You begin your journey in the **Village of Oakhaven**. The sun is setting and the village elder greets you at the gate. Take a moment to explore — there are several important items to pick up before heading out.\n\nHead to the **village square** and talk to the merchant near the fountain. He'll offer you a basic sword for free if you mention the elder sent you. Be sure to grab the **Starting Item** from the chest behind the merchant stall.\n\n<!-- checkpoint: village-explored | Explored Oakhaven Village -->\n\n## The Red Door\n\nOn the east side of town you'll notice a conspicuous red door. **Do NOT open it yet** — doing so triggers a cutscene that locks you out of a collectible in the western alley. Come back after completing the side quest \"Lost Heirloom\" which becomes available in Chapter 2.\n\nInstead, head west past the blacksmith. Behind the waterfall at the end of the alley, you'll find the **Missable Trophy Item** sitting on a pedestal. This is the only time you can grab it.\n\n<!-- checkpoint: collectibles-secured | Secured missable collectibles -->\n\n## Boss: The First Guardian\n\nWhen you're ready, head north to the gate. The **First Guardian** blocks your path. This is a straightforward fight — stay behind it and attack the glowing weak point on its back. It telegraphs its slam attack by raising both arms, giving you about 2 seconds to dodge.\n\n**Strategy:** Use the pillars for cover during its ranged phase. When it kneels (around 30% HP), unleash everything you have.\n\n**Reward:** Guardian's Key — opens the north gate to Chapter 2.\n\n<!-- checkpoint: guardian-defeated | Defeated the First Guardian -->",
+      "checkpoints": [
+        { "id": "village-explored", "label": "Explored Oakhaven Village" },
+        { "id": "collectibles-secured", "label": "Secured missable collectibles" },
+        { "id": "guardian-defeated", "label": "Defeated the First Guardian" }
+      ],
       "steps": [
         {
           "id": "step-001",
           "type": "step",
-          "text": "Pick up the **Starting Item** from the chest."
+          "text": "Pick up the **Starting Item** from the chest behind the merchant."
         },
         {
           "id": "step-002",
           "type": "warning",
           "text": "Do NOT open the red door yet — it locks you out of a collectible.",
-          "note": "Come back after completing the side quest."
+          "note": "Come back after completing the side quest in Chapter 2."
         },
         {
           "id": "step-003",

--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ The server is available at `http://localhost:8080`.
 
 See [docs/adding-a-walkthrough.md](docs/adding-a-walkthrough.md) for the manual process, or use the **Copilot walkthrough ingestion skill** (`.github/copilot/skills/walkthrough-ingest.md`) to have Copilot convert any online walkthrough into the correct JSON format automatically.
 
+## Walkthrough format
+
+Each walkthrough section supports **two complementary content modes**:
+
+| Field | Purpose |
+|---|---|
+| `content` | Full walkthrough prose in Markdown with embedded milestone checkpoints |
+| `checkpoints` | Array of milestone markers (`id` + `label`) referenced in the prose |
+| `steps` | Granular checkable action items (classic checklist) |
+
+When a section has `content`, the app renders the full prose as the primary view with interactive 🏁 milestone checkpoints embedded inline. Granular `steps` appear in a collapsible "Detailed steps" panel. Sections without `content` render the classic step-only checklist.
+
+Milestone checkpoints are embedded in the Markdown prose using HTML comments:
+```
+<!-- checkpoint: boss-defeated | Defeated the First Boss -->
+```
+
 ## Step type legend
 
 | Icon | Type | Meaning |

--- a/docs/adding-a-walkthrough.md
+++ b/docs/adding-a-walkthrough.md
@@ -16,7 +16,7 @@ Or paste raw text:
 Here is the walkthrough text: [paste the text]
 ```
 
-Copilot will output a JSON file matching the schema.
+Copilot will output a JSON file matching the schema — including full prose `content` with embedded milestone checkpoints plus granular `steps`.
 
 ## Step 2: Save the file
 
@@ -32,7 +32,10 @@ Example: `walkthroughs/elden-ring/main-walkthrough.json`
 Check that:
 - `attribution` field credits the original source
 - `id` is a unique slug (lowercase, hyphens only)
-- Sections and steps make sense
+- Sections have a `content` field with full walkthrough prose (not abbreviated)
+- Checkpoint markers (`<!-- checkpoint: id | label -->`) appear at major milestones in the content
+- The `checkpoints` array matches every marker in the content
+- Granular `steps` array provides a concise checklist alongside the prose
 - `type` values are correct (`step`, `note`, `warning`, `collectible`, `boss`)
 
 ## Step 4: Commit and push
@@ -52,6 +55,25 @@ All devices will get the new walkthrough on their next sync.
 ## Schema reference
 
 See [walkthrough.schema.json](../walkthroughs/walkthrough.schema.json) for the full schema.
+
+### Section content format
+
+Each section supports two complementary content modes:
+
+| Field | Purpose |
+|---|---|
+| `content` | Full walkthrough prose in Markdown with embedded `<!-- checkpoint: id \| label -->` markers |
+| `checkpoints` | Array of `{ id, label }` objects matching each checkpoint marker in content |
+| `steps` | Granular checkable action items (classic checklist) |
+
+Sections must have at least `content` or `steps` (or both). When both are present, the webapp shows the full prose as the primary view with steps in a collapsible panel.
+
+### Checkpoint syntax
+
+Inside the `content` markdown, embed milestones like:
+```
+<!-- checkpoint: boss-defeated | Defeated the First Boss -->
+```
 
 ### Step types
 

--- a/walkthroughs/example-dark-souls/main-walkthrough.json
+++ b/walkthroughs/example-dark-souls/main-walkthrough.json
@@ -11,78 +11,281 @@
     {
       "id": "undead-asylum",
       "title": "Undead Asylum",
+      "content": "# Undead Asylum\n\nThe Undead Asylum is the tutorial area of Dark Souls Remastered and the first location you will explore. It is a crumbling hilltop prison where the Undead are locked away to await the end of the world. Despite its brevity, the Asylum teaches you everything you need to know about Dark Souls: exploration, caution, combat timing, and the crushing weight of a boss encounter.\n\n<!-- checkpoint: cell-escape | Escape the Starting Cell -->\n\n## Escape the Starting Cell\n\nYou awaken in a dank cell deep within the Asylum. The opening cinematic has told you of the Undead prophecy and the Chosen Undead — that's you, though you don't look like much right now. Your cell is bare except for a corpse slumped against the far wall.\n\nLoot the **Dungeon Cell Key** from the corpse. This is your ticket out. Use it on the cell door and step into the corridor beyond. The hallway is lined with more cells, all sealed shut. A few hollowed prisoners claw at the bars but cannot reach you.\n\nProceed forward and up the short staircase. On the right side of the steps you'll find another corpse holding the **Straight Sword Hilt** — a broken weapon that deals pitiful damage, but it's all you have for now. Pick it up; you'll need something to swing.\n\nAt the top of the stairs you emerge into a small courtyard open to the sky. There is a **bonfire** here — your first. Light it and rest. This is Dark Souls' checkpoint system: resting refills your Estus Flask (once you have it), resets most enemies, and serves as your respawn point on death.\n\n<!-- checkpoint: first-bonfire | Light the First Bonfire -->\n\n## The Large Hall & First Demon Encounter\n\nFrom the bonfire courtyard, proceed through the large double doors ahead. You enter an enormous hall with a vaulted ceiling. The floor is littered with rubble and broken pillars.\n\nAs you move toward the center of the room, the **Asylum Demon** crashes down from above — a massive, bloated creature wielding a stone hammer the size of a wagon. With only the Straight Sword Hilt (or bare fists), you deal almost no damage to this beast.\n\n**Do NOT fight it.** Instead, look to the far-left wall. There is a small doorway — sprint toward it. The Demon's overhead slam has a long wind-up, so roll through its attack and dash through the door. A fog gate seals behind you, and you're safe.\n\nIf you are experienced and chose the **Black Firebombs** as your starting gift, you can actually kill the Asylum Demon here for the **Demon's Great Hammer** — but this is an advanced strategy not recommended for first-time players.\n\n<!-- checkpoint: oscar-encounter | Meet Oscar of Astora -->\n\n## The Refuge Hallway & Oscar of Astora\n\nBeyond the fog gate is a narrow hallway leading upward. Light the **second bonfire** partway up the corridor. Continue climbing the stairs.\n\n**Boulder Trap:** As you ascend the next staircase, a massive boulder rolls down toward you. Sprint back or dodge sideways. The boulder smashes through the wall behind you, revealing a hidden alcove.\n\nInside this alcove lies **Oscar, Knight of Astora** — mortally wounded and slumped against the wall. Speak with him. Oscar recognizes you as Undead and gifts you the **Estus Flask** (your primary healing item, refills at bonfires) and the **Undead Asylum F2 East Key**.\n\nOscar speaks of a prophecy: *\"Thou who art Undead, art chosen. In thine exodus from the Undead Asylum, maketh pilgrimage to the land of Ancient Lords.\"* He then slumps over. He will hollow later — if you return to this room after defeating the boss, he attacks on sight and drops the **Crest Shield**.\n\n<!-- checkpoint: retrieve-equipment | Retrieve Your Equipment -->\n\n## Retrieve Your Starting Equipment\n\nWith the F2 East Key in hand, proceed up past the boulder trap area. At the top of the stairs, unlock the gate on the right side. Beyond it is a narrow corridor lined with hollow soldiers — slow, shambling enemies that attack with broken swords.\n\nThese are your first real combat encounters. Practice your timing: raise your shield to block, then counter-attack. Or try rolling through their swings for backstab opportunities.\n\nAlong this upper walkway, you will find:\n\n- Your **class shield** on a corpse along the railing\n- Your **class weapon** at the end of the corridor (the weapon depends on what class you chose at character creation)\n- A few **Soul of a Lost Undead** items on scattered corpses\n\nThere are also **hollow archers** on elevated platforms. They fire slowly but can stagger you mid-fight. Prioritize closing the distance or using pillars as cover.\n\nEquip your weapon and shield immediately. You are now properly armed.\n\n<!-- checkpoint: fog-gate-return | Return to the Demon Arena -->\n\n## Return to the Demon Arena\n\nWith your real weapon equipped, it's time to face the Asylum Demon properly. Make your way back through the upper corridors until you reach a fog gate overlooking the large hall from above. You are now on a ledge directly above the Asylum Demon.\n\nBefore dropping down, ensure your Estus Flask is equipped and your weapon is two-handed (if you prefer damage over blocking). Take a breath. Step off the ledge.\n\n<!-- checkpoint: asylum-demon-boss | Boss: Asylum Demon -->\n\n## Boss Fight: Asylum Demon\n\n**Asylum Demon** is a large, slow creature with devastating but highly telegraphed attacks.\n\n### Plunging Attack\n\nAs you drop from the ledge, press your attack button (R1/RB) while falling. This executes a **plunging attack** that deals roughly 30-40% of the Demon's health in one strike. This is by far the most efficient opening.\n\n### Attack Patterns\n\n- **Overhead Slam:** The Demon raises its hammer high and crashes it down. Huge damage, but very slow. Roll sideways.\n- **Horizontal Sweep:** A wide arc in front of the Demon. Roll backward or toward its legs.\n- **Butt Slam (AoE):** The Demon leaps and lands on its backside, creating a shockwave. Sprint away when you see it jump.\n- **Fly & Slam:** At range, the Demon can briefly fly toward you and slam. Roll sideways on landing.\n\n### Strategy\n\nAfter the plunging attack, run behind the Demon and stay near its tail/legs. Most of its attacks swing in front, so the rear is safest. Get in 1-2 hits after each of its attack animations, then back off. Be patient — greed kills more players than the Demon itself.\n\nHeal with Estus when below 50% HP. You have 5 charges; that's more than enough if you play carefully.\n\n**Reward:** Defeating the Asylum Demon grants you the **Big Pilgrim's Key** and a large chunk of souls.\n\n<!-- checkpoint: exit-asylum | Exit the Asylum -->\n\n## Exit the Asylum\n\nWith the Big Pilgrim's Key, exit through the massive iron doors at the far end of the hall (opposite from where you first entered). A short path leads you outside to a cliff edge overlooking a vast landscape.\n\nStep forward onto the rocky promontory. After a moment, the **Giant Crow** swoops down, grasps you in its talons, and carries you away from the Asylum. A cinematic plays showing you soaring over the land of Lordran.\n\nYou are deposited at **Firelink Shrine** — the central hub of Dark Souls. The real journey begins now.\n\n*Note: You can return to the Undead Asylum later in the game by curling up in the crow's nest at Firelink Shrine. The return trip features new enemies, the Stray Demon boss, and additional loot including the Rusted Iron Ring.*",
+      "checkpoints": [
+        {
+          "id": "cell-escape",
+          "label": "Escape the Starting Cell"
+        },
+        {
+          "id": "first-bonfire",
+          "label": "Light the First Bonfire"
+        },
+        {
+          "id": "oscar-encounter",
+          "label": "Meet Oscar of Astora"
+        },
+        {
+          "id": "retrieve-equipment",
+          "label": "Retrieve Your Equipment"
+        },
+        {
+          "id": "fog-gate-return",
+          "label": "Return to the Demon Arena"
+        },
+        {
+          "id": "asylum-demon-boss",
+          "label": "Boss: Asylum Demon"
+        },
+        {
+          "id": "exit-asylum",
+          "label": "Exit the Asylum"
+        }
+      ],
       "steps": [
         {
-          "id": "step-001",
-          "type": "step",
-          "text": "Pick up the **Dungeon Cell Key** from the corpse near the starting cell.",
-          "note": "It's on the body right next to where you start."
-        },
-        {
-          "id": "step-002",
-          "type": "step",
-          "text": "Unlock the cell door and head upstairs."
-        },
-        {
-          "id": "step-003",
+          "id": "loot-cell-key",
           "type": "collectible",
-          "text": "Pick up the **Straight Sword Hilt** from the corpse on the steps.",
-          "note": "Missable if you rush past — it's on the right side of the staircase."
+          "text": "Pick up the **Dungeon Cell Key** from the corpse in your starting cell.",
+          "note": "It's on the body slumped against the far wall."
         },
         {
-          "id": "step-004",
+          "id": "escape-cell",
           "type": "step",
-          "text": "Grab the **Estus Flask** from the altar in the large room."
+          "text": "Use the key to unlock the cell door and exit into the corridor."
         },
         {
-          "id": "step-005",
+          "id": "loot-sword-hilt",
+          "type": "collectible",
+          "text": "Pick up the **Straight Sword Hilt** from the corpse on the right side of the staircase.",
+          "note": "A broken weapon — weak but better than bare fists."
+        },
+        {
+          "id": "light-first-bonfire",
+          "type": "step",
+          "text": "Light the **bonfire** in the small courtyard at the top of the stairs."
+        },
+        {
+          "id": "enter-large-hall",
+          "type": "step",
+          "text": "Pass through the large double doors into the main hall."
+        },
+        {
+          "id": "first-demon-encounter",
           "type": "warning",
-          "text": "Do NOT fight the Asylum Demon head-on your first encounter. Run past it through the fog gate on the left.",
-          "note": "You can come back to fight it properly after getting your starting weapon."
+          "text": "The **Asylum Demon** drops from the ceiling. Do NOT fight it — sprint to the far-left doorway and through the fog gate.",
+          "note": "You can kill it here with Black Firebombs for the Demon's Great Hammer, but this is an advanced tactic."
         },
         {
-          "id": "step-006",
+          "id": "light-second-bonfire",
           "type": "step",
-          "text": "Drop down to the fog gate room and pick up your **starting gift** and **Humanity** if applicable."
+          "text": "Light the **second bonfire** in the refuge hallway beyond the fog gate."
         },
         {
-          "id": "step-007",
+          "id": "boulder-trap",
+          "type": "warning",
+          "text": "A boulder rolls down the staircase as you ascend. Dodge sideways or sprint back to avoid it.",
+          "note": "The boulder breaks through the wall, revealing Oscar's alcove."
+        },
+        {
+          "id": "meet-oscar",
+          "type": "step",
+          "text": "Speak with **Oscar, Knight of Astora** in the revealed alcove. He gives you the **Estus Flask** and the **Undead Asylum F2 East Key**."
+        },
+        {
+          "id": "loot-estus-flask",
+          "type": "collectible",
+          "text": "Receive the **Estus Flask** from Oscar — your primary healing item (refills at bonfires, starts with 5 charges)."
+        },
+        {
+          "id": "loot-f2-key",
+          "type": "collectible",
+          "text": "Receive the **Undead Asylum F2 East Key** from Oscar."
+        },
+        {
+          "id": "unlock-upper-corridor",
+          "type": "step",
+          "text": "Use the F2 East Key to unlock the gate at the top of the stairs and proceed into the upper corridor."
+        },
+        {
+          "id": "fight-hollows",
+          "type": "step",
+          "text": "Defeat the **hollow soldiers** in the corridor. Practice blocking and counter-attacking."
+        },
+        {
+          "id": "loot-class-shield",
+          "type": "collectible",
+          "text": "Pick up your **class shield** from a corpse along the upper walkway railing."
+        },
+        {
+          "id": "loot-class-weapon",
+          "type": "collectible",
+          "text": "Pick up your **class weapon** at the end of the corridor.",
+          "note": "The weapon depends on your chosen starting class."
+        },
+        {
+          "id": "loot-souls-upper",
+          "type": "collectible",
+          "text": "Collect **Soul of a Lost Undead** items from corpses scattered along the upper walkway."
+        },
+        {
+          "id": "deal-with-archers",
+          "type": "note",
+          "text": "Watch for **hollow archers** on elevated platforms. Use pillars as cover or close the distance quickly."
+        },
+        {
+          "id": "equip-gear",
+          "type": "step",
+          "text": "Equip your class weapon and shield from the inventory menu."
+        },
+        {
+          "id": "return-to-arena",
+          "type": "step",
+          "text": "Navigate back through the upper corridors to the fog gate overlooking the large hall from above."
+        },
+        {
+          "id": "boss-asylum-demon",
           "type": "boss",
-          "text": "**BOSS: Asylum Demon** — Attack from behind after the plunge attack. Use the plunging attack from the ledge for massive damage.",
-          "note": "Reward: Big Pilgrim's Key"
+          "text": "**BOSS: Asylum Demon** — Drop from the ledge and press attack while falling for a devastating **plunging attack** (deals ~35% of its health). Stay behind the Demon, attack 1-2 times after each of its swings, and heal below 50% HP.",
+          "note": "Reward: Big Pilgrim's Key. Avoid greed — wait for openings after its overhead slam and horizontal sweep."
         },
         {
-          "id": "step-008",
+          "id": "loot-pilgrims-key",
+          "type": "collectible",
+          "text": "Receive the **Big Pilgrim's Key** upon defeating the Asylum Demon."
+        },
+        {
+          "id": "exit-asylum",
           "type": "step",
-          "text": "Use the Big Pilgrim's Key to exit the Asylum. Watch the cutscene."
+          "text": "Use the Big Pilgrim's Key to open the massive iron doors and walk to the cliff edge. The Giant Crow carries you to Firelink Shrine."
+        },
+        {
+          "id": "optional-return-oscar",
+          "type": "note",
+          "text": "Optional: Return to Oscar's alcove after the boss fight. He has hollowed and attacks on sight. Defeat him for the **Crest Shield**.",
+          "note": "This is missable if you leave the Asylum without returning."
         }
       ]
     },
     {
       "id": "firelink-shrine",
       "title": "Firelink Shrine",
+      "content": "# Firelink Shrine\n\nFirelink Shrine is the central hub of Dark Souls Remastered. Nestled among ancient ruins overlooking a flooded basin, it serves as your home base throughout the entire game. Multiple paths branch outward from here to the various regions of Lordran, and friendly NPCs gradually congregate at the Shrine as you progress.\n\nThe Shrine's bonfire is unique — it is tended by a **Fire Keeper**, which means it provides more Estus charges than a standard bonfire (10 instead of 5). This makes it an ideal place to return between expeditions.\n\n<!-- checkpoint: arrive-firelink | Arrive at Firelink Shrine -->\n\n## Arrival\n\nThe Giant Crow deposits you on a grassy cliff above the Shrine. Descend the short slope to find the **Firelink bonfire** — a crackling flame surrounded by ancient stonework. Rest here to set your spawn point and refill your Estus Flask (you now receive 10 charges thanks to the Fire Keeper).\n\nTake a moment to survey the area. Firelink Shrine is a ruined plaza built into a hillside, with stairways leading up and down in several directions. The sky is grey and overcast. The sound of distant bells and dripping water fills the air.\n\n<!-- checkpoint: meet-crestfallen | Meet the Crestfallen Warrior -->\n\n## NPCs at the Shrine\n\n### Crestfallen Warrior\n\nSitting on the stone steps near the bonfire is the **Crestfallen Warrior** — a cynical, world-weary Undead in chain mail. Speak with him for invaluable early-game guidance. He tells you about the two Bells of Awakening — one above in the Undead Church, one below in Blighttown — and warns you about the dangers ahead.\n\nHe's sarcastic and dismissive, but his information is accurate. Exhaust his dialogue on each visit; he updates his lines as you progress.\n\n### Anastacia of Astora (Fire Keeper)\n\nBelow the bonfire, accessible via a staircase behind and beneath the main platform, you'll find **Anastacia of Astora** imprisoned behind iron bars. She is the Fire Keeper who tends this bonfire. She cannot speak (her tongue was removed) but plays a vital role:\n\n- She keeps the Firelink bonfire lit\n- She can reinforce your Estus Flask if you bring her **Fire Keeper Souls** (found throughout the game)\n- If she dies, the Firelink bonfire goes dark until you avenge her\n\nDo NOT attack her. She is essential.\n\n### Petrus of Thorolund\n\nTo the right of the bonfire (when facing the cliff edge), descend a few steps to find **Petrus of Thorolund** — a portly cleric who serves as your first Miracle merchant. He sells basic miracles like **Heal** and offers to teach you about Covenants.\n\nHe later plays a role in the Rhea of Thorolund questline. For now, buy **Heal** if you're running a Faith build.\n\n### Other NPCs (Arrive Later)\n\nAs you progress through the game, additional NPCs will appear at Firelink Shrine:\n\n- **Knight Lautrec of Carim** — freed from Undead Parish, sits near the bonfire. Treacherous.\n- **Laurentius of the Great Swamp** — rescued from the Depths. Pyromancy trainer.\n- **Griggs of Vinheim** — rescued from Lower Undead Burg. Sorcery merchant.\n- **Siegmeyer of Catarina** — appears at various points in his questline.\n- **Kingseeker Frampt** — the primordial serpent, appears after ringing both Bells of Awakening.\n\n<!-- checkpoint: explore-items | Explore for Items -->\n\n## Item Locations\n\nFirelink Shrine contains a surprising number of useful items scattered across its various levels and ledges. Explore thoroughly before venturing onward.\n\n### Near the Bonfire\n\n- **Homeward Bone x6** — on a corpse between the bonfire and the elevator tower (leads to New Londo Ruins)\n- **Soul of a Lost Undead** — on a corpse near the cliff edge behind the bonfire\n\n### The Well & Surrounding Area\n\n- **Humanity** — on a corpse near the stone well to the left of the bonfire\n- **Twin Humanities** — behind the well arch, partially hidden in shadow\n- **Soul of a Lost Undead** — on a corpse on the ledge above the well (accessible from the aqueduct path)\n\n### Elevator Tower Area\n\n- **Binoculars** — on a corpse along the cliff edge near the elevator down to New Londo Ruins. Useful for scoping out areas from a distance.\n\n### The Graveyard (Southwest)\n\nDescending the slope past Petrus leads to the **Graveyard** — a dangerous area filled with skeletons that reassemble after being destroyed (unless you have a divine weapon). Despite the danger, several valuable items are here:\n\n- **Winged Spear** — on a corpse among the first few graves\n- **Soul items** — scattered on corpses throughout\n- **Zweihander** — a massive ultra-greatsword on a corpse near the large gravestone at the bottom of the hill\n- **Binoculars** — if you missed them near the elevator\n\n**Warning:** The skeletons here are far too strong for a new character. Grab items by sprinting in, looting, and sprinting out. Do NOT try to clear the graveyard at this stage.\n\n### New Londo Ruins (Below)\n\nThe elevator near the bonfire descends to New Londo Ruins. This flooded ghost city is extremely dangerous early on (ghosts are invincible without Transient Curses). However, just past the initial bridge you can find:\n\n- **Fire Keeper Soul** — on a corpse on a rooftop in the ruins. This can be given to Anastacia to upgrade your Estus Flask.\n\nGrab it and immediately return to the elevator. Do NOT explore further until much later in the game.\n\n<!-- checkpoint: understand-routes | Understand the Routes -->\n\n## Routes from Firelink Shrine\n\nFirelink Shrine connects to several areas. Understanding your options early prevents wasted time and frustration.\n\n### Undead Burg (Recommended First)\n\nClimb the staircase that leads up from the bonfire area, past the aqueduct waterway. This leads to the **Undead Burg** — the intended first area after the Asylum. Enemies here are manageable and the path leads logically toward the first Bell of Awakening.\n\n### New Londo Ruins (Dangerous — Later)\n\nTake the elevator down from the tower near the bonfire. New Londo Ruins is populated by ghosts that require **Transient Curses** to damage. This is a mid-to-late-game area.\n\n### The Catacombs (Dangerous — Later)\n\nDescend through the Graveyard and continue downhill. The Catacombs are the path to Nito and the second Bell of Awakening (Blighttown is actually the intended route to the second bell for new players).\n\n### Valley of Drakes (Requires Key)\n\nA locked gate near the New Londo elevator leads to the Valley of Drakes. You need the **Master Key** (starting gift or found later) to access this shortcut.\n\n<!-- checkpoint: level-up-prep | Prepare for Undead Burg -->\n\n## Preparing for Undead Burg\n\nBefore leaving Firelink Shrine, make sure you have:\n\n1. **Rested at the bonfire** — full 10 Estus charges\n2. **Equipped your best weapon and shield** from the Asylum\n3. **Spoken to the Crestfallen Warrior** — he confirms your path: \"There are actually two Bells of Awakening... one up above, in the Undead Church, and one far, far below, in the ruins at the base of Blighttown.\"\n4. **Collected nearby items** — at minimum the Humanity and Homeward Bones\n5. **Optionally purchased Heal from Petrus** — if running a Faith build\n\nWhen ready, ascend the stairs toward the aqueduct. The path to Undead Burg awaits.\n\n<!-- checkpoint: depart-firelink | Depart for Undead Burg -->\n\n## Lore Notes\n\nFirelink Shrine was once a place of great significance — a nexus where the First Flame was linked by past heroes. The bonfire here burns with unusual intensity because of Anastacia's sacrifice. The ruins suggest a once-grand structure, now eroded by untold centuries.\n\nThe name itself — \"Firelink\" — refers to the act of linking the First Flame, the central choice that defines the game's ending. Every Lord of Cinder before you began their journey from a place like this.\n\nAs you progress, watch how the Shrine changes: NPCs arrive and depart, the atmosphere shifts, and the consequences of your choices ripple outward from this quiet, grey hub at the center of the world.",
+      "checkpoints": [
+        {
+          "id": "arrive-firelink",
+          "label": "Arrive at Firelink Shrine"
+        },
+        {
+          "id": "meet-crestfallen",
+          "label": "Meet the Crestfallen Warrior"
+        },
+        {
+          "id": "explore-items",
+          "label": "Explore for Items"
+        },
+        {
+          "id": "understand-routes",
+          "label": "Understand the Routes"
+        },
+        {
+          "id": "level-up-prep",
+          "label": "Prepare for Undead Burg"
+        },
+        {
+          "id": "depart-firelink",
+          "label": "Depart for Undead Burg"
+        }
+      ],
       "steps": [
         {
-          "id": "step-009",
+          "id": "rest-at-firelink-bonfire",
           "type": "step",
-          "text": "Talk to **Kingseeker Frampt** (if he appears) — not required, just lore."
+          "text": "Rest at the **Firelink bonfire** to set your spawn point and refill Estus (10 charges from the Fire Keeper)."
         },
         {
-          "id": "step-010",
-          "type": "collectible",
-          "text": "Grab the **Humanity** and **Twin Humanities** from the corpses near the well.",
-          "note": "One is by the well, the other is behind the well arch."
+          "id": "talk-crestfallen-warrior",
+          "type": "step",
+          "text": "Talk to the **Crestfallen Warrior** sitting on the steps near the bonfire. He explains the two Bells of Awakening.",
+          "note": "Exhaust his dialogue — he gives critical guidance about where to go next."
         },
         {
-          "id": "step-011",
+          "id": "find-anastacia",
           "type": "note",
-          "text": "Firelink Shrine is your main hub. You can warp back here by resting at the bonfire.",
-          "note": "The NPC Anastacia of Astora is imprisoned below the bonfire — she is the Fire Keeper."
+          "text": "**Anastacia of Astora** (Fire Keeper) is imprisoned below the bonfire behind iron bars. She reinforces your Estus Flask with Fire Keeper Souls.",
+          "note": "Do NOT attack her — if she dies, the Firelink bonfire goes out."
         },
         {
-          "id": "step-012",
+          "id": "talk-petrus",
           "type": "step",
-          "text": "Decide your next area: **Undead Burg** (recommended first) or **New Londo Ruins** (dangerous)."
+          "text": "Speak with **Petrus of Thorolund** to the right of the bonfire (down a few steps). He sells miracles and explains Covenants.",
+          "note": "Buy Heal if you're a Faith build."
+        },
+        {
+          "id": "loot-homeward-bones",
+          "type": "collectible",
+          "text": "Pick up **Homeward Bone x6** from the corpse between the bonfire and the elevator tower."
+        },
+        {
+          "id": "loot-humanity-well",
+          "type": "collectible",
+          "text": "Grab the **Humanity** from the corpse near the stone well (left of the bonfire)."
+        },
+        {
+          "id": "loot-twin-humanities",
+          "type": "collectible",
+          "text": "Pick up **Twin Humanities** from behind the well arch, partially hidden in shadow."
+        },
+        {
+          "id": "loot-souls-cliff",
+          "type": "collectible",
+          "text": "Collect **Soul of a Lost Undead** from the corpse near the cliff edge behind the bonfire."
+        },
+        {
+          "id": "loot-binoculars",
+          "type": "collectible",
+          "text": "Grab the **Binoculars** from the corpse along the cliff edge near the New Londo elevator.",
+          "note": "Useful for scoping out areas and sniping with bows or spells."
+        },
+        {
+          "id": "graveyard-warning",
+          "type": "warning",
+          "text": "The **Graveyard** (southwest, past Petrus) has powerful skeletons that reassemble. Do NOT try to clear it at this stage.",
+          "note": "You can sprint in to grab the Winged Spear and Zweihander, then sprint out."
+        },
+        {
+          "id": "loot-winged-spear",
+          "type": "collectible",
+          "text": "Sprint into the Graveyard and grab the **Winged Spear** from a corpse among the first graves.",
+          "note": "Immediately run back — the skeletons will overwhelm you."
+        },
+        {
+          "id": "loot-zweihander",
+          "type": "collectible",
+          "text": "Optional: Sprint to the large gravestone at the bottom of the hill for the **Zweihander** (powerful ultra-greatsword).",
+          "note": "Very risky at low level. Consider coming back later."
+        },
+        {
+          "id": "new-londo-fire-keeper-soul",
+          "type": "collectible",
+          "text": "Take the elevator down to New Londo Ruins and grab the **Fire Keeper Soul** from the corpse on the rooftop just past the first bridge.",
+          "note": "Give this to Anastacia to upgrade your Estus Flask. Return to the elevator immediately after."
+        },
+        {
+          "id": "new-londo-warning",
+          "type": "warning",
+          "text": "Do NOT explore New Londo Ruins beyond the Fire Keeper Soul. Ghosts here require **Transient Curses** to damage and are deadly at low level."
+        },
+        {
+          "id": "prepare-undead-burg",
+          "type": "step",
+          "text": "Ensure you have: full 10 Estus, your best weapon and shield equipped, and nearby items collected."
+        },
+        {
+          "id": "head-to-undead-burg",
+          "type": "step",
+          "text": "Climb the staircase leading up from the bonfire area, past the aqueduct, to reach **Undead Burg** — the recommended first area.",
+          "note": "This is the path toward the first Bell of Awakening."
         }
       ]
     }

--- a/walkthroughs/tales-of-berseria/main-walkthrough.json
+++ b/walkthroughs/tales-of-berseria/main-walkthrough.json
@@ -11,6 +11,21 @@
     {
       "id": "prologue",
       "title": "Prologue",
+      "content": "## Prologue — The Scarlet Night\n\nThe game opens with a peaceful flashback to the village of **Aball**, where a young Velvet Crowe lives with her brother Laphicet and brother-in-law Arthur (Artorius). This idyllic scene establishes the bonds that will drive Velvet’s revenge throughout the entire story. Pay attention to the dialogue here — it sets up critical plot points.\n\n<!-- checkpoint: prologue-village | Village of Aball flashback -->\n\nAfter the opening flashback, the scene shifts dramatically. Velvet awakens in a dark prison cell on the island fortress of **Titania**, where she has been imprisoned for three years. A mysterious Malak named **Seres** appears and frees Velvet from her cell. The game introduces basic movement and camera controls during this sequence.\n\n### Tutorial Battle\n\nYour first fight is against a daemon in the prison cell. The game walks you through the basic combat system:\n\n- **Normal attacks** chain into combos (up to 3 hits initially)\n- **Artes** are mapped to face buttons during combat\n- **Break Soul** is Velvet’s unique Therionization mechanic — when prompted, activate it to consume enemies and heal\n\n<!-- checkpoint: prologue-tutorial | Tutorial battle completed -->\n\nThis daemon fight cannot be lost and serves purely as a combat tutorial. Use Break Soul when the prompt appears to learn Velvet’s signature ability — her left arm transforms into a daemonic claw that devours enemies.\n\n### Following Seres\n\nAfter the tutorial, follow Seres through the prison hallways. The path is completely linear at this point. Seres will blast through locked doors and handle most obstacles. Along the way, you’ll encounter your first proper enemy fights against prison guards (exorcists).\n\nThese corridor battles are straightforward — use basic combos and don’t worry about resource management. Seres fights alongside you as a guest party member and contributes significant damage.\n\n<!-- checkpoint: prologue-escape | Escaped the prison cell -->\n\nThe prologue concludes with major story revelations and sets Velvet on her path of vengeance. Watch the cutscenes carefully — they establish the central conflict of the entire game.",
+      "checkpoints": [
+        {
+          "id": "prologue-village",
+          "label": "Village of Aball flashback"
+        },
+        {
+          "id": "prologue-tutorial",
+          "label": "Tutorial battle completed"
+        },
+        {
+          "id": "prologue-escape",
+          "label": "Escaped the prison cell"
+        }
+      ],
       "steps": [
         {
           "id": "step-001",
@@ -20,8 +35,8 @@
         {
           "id": "step-002",
           "type": "step",
-          "text": "Complete the tutorial battle against the daemon in Velvet's prison cell.",
-          "note": "Use Break Soul when prompted to learn Velvet's Therionization mechanic."
+          "text": "Complete the tutorial battle against the daemon in Velvet’s prison cell.",
+          "note": "Use Break Soul when prompted to learn Velvet’s Therionization mechanic."
         },
         {
           "id": "step-003",
@@ -39,17 +54,40 @@
     {
       "id": "titania-1",
       "title": "Titania (1st Visit)",
+      "content": "## Titania — Prison Island Escape\n\nAfter the prologue events, Velvet must fight her way through the Titania prison fortress alongside Seres. This section introduces deeper combat mechanics and features your first real boss encounter.\n\n### Boss: Seres\n\nImmediately after regaining control, you face **Seres** in a tutorial boss fight.\n\n- **HP:** 2,200\n- **Strategy:** Guard to accumulate Souls, then counterattack with full combos\n- **Reward:** Prodigy’s Glacite\n\n<!-- checkpoint: titania-seres-boss | Defeated Seres (tutorial boss) -->\n\nThis fight cannot be lost — it exists to teach you about Soul management and the guard/counter flow of combat. When you guard enemy attacks successfully, you gain Souls which extend your combo length.\n\n### Prison Block Exploration\n\nAfter the battle, exit the room and follow the linear path forward. Open the first chest you encounter for Velvet’s basic equipment. **Immediately open the party menu and equip everything** — check weapon, armor, and accessory slots.\n\nThe prison block has multiple cells and side rooms worth exploring:\n\n- **Northwest cell (last one):** Battle Boots\n- **Storage room to the south:** Sage\n- **Eastern cell block:** Life Bottle\n- **Upstairs northeast area:** Void Ring\n\n<!-- checkpoint: titania-items | Collected prison block items -->\n\nTake your time exploring — enemies here are weak and provide good early experience. Check every cell door and interact with all sparkle points on the ground.\n\n### Upper Floors & Rokurou\n\nHead upstairs and south to encounter exorcist enemies. These are slightly tougher than the guards below but still manageable with basic combos and Break Soul.\n\n<!-- checkpoint: titania-rokurou | Encountered Rokurou -->\n\n### Boss: Red-Eyed Swordsman (Rokurou)\n\nAfter clearing the upper-floor exorcists, you encounter a prisoner with red eyes — **Rokurou Rangetsu**.\n\n- **HP:** 2,843 (only need to reduce to 50%)\n- **Strategy:** Seres assists in this fight. Focus on landing combos when Rokurou finishes his attack strings\n- **Reward:** Sharpshooter’s Ventite\n\n<!-- checkpoint: titania-rokurou-boss | Defeated Rokurou -->\n\nRokurou is fast but predictable — he always follows a three-hit combo pattern. Guard through his attacks, then counter. Once his HP drops to 50%, the fight ends and he joins your escape.\n\n### Escape Sequence\n\nAfter defeating Rokurou:\n1. Defeat the three guards that appear\n2. Ascend the ladder and collect **320 Gald** from the chest at the top\n3. Watch the concluding cutscenes as the party escapes the prison\n\n<!-- checkpoint: titania-escape | Escaped Titania -->\n\nThe escape sequence features important story cutscenes — Seres sacrifices herself, and Velvet gains her full daemonic power. This is a pivotal moment that shapes the rest of the narrative.",
+      "checkpoints": [
+        {
+          "id": "titania-seres-boss",
+          "label": "Defeated Seres (tutorial boss)"
+        },
+        {
+          "id": "titania-items",
+          "label": "Collected prison block items"
+        },
+        {
+          "id": "titania-rokurou",
+          "label": "Encountered Rokurou"
+        },
+        {
+          "id": "titania-rokurou-boss",
+          "label": "Defeated Rokurou"
+        },
+        {
+          "id": "titania-escape",
+          "label": "Escaped Titania"
+        }
+      ],
       "steps": [
         {
           "id": "step-005",
           "type": "boss",
           "text": "**BOSS: Seres** — HP: 2,200. Guard to gain Souls, then counterattack.",
-          "note": "Reward: Prodigy's Glacite. This is a tutorial boss — you can't lose."
+          "note": "Reward: Prodigy’s Glacite. This is a tutorial boss — you can’t lose."
         },
         {
           "id": "step-006",
           "type": "step",
-          "text": "Exit the room after the battle and follow the linear path. Open the chest for Velvet's basic gear."
+          "text": "Exit the room after the battle and follow the linear path. Open the chest for Velvet’s basic gear."
         },
         {
           "id": "step-007",
@@ -87,7 +125,7 @@
           "id": "step-013",
           "type": "boss",
           "text": "**BOSS: Red-Eyed Swordsman (Rokurou)** — HP: 2,843. Only need to drop HP to 50%.",
-          "note": "Seres assists. Reward: Sharpshooter's Ventite."
+          "note": "Seres assists. Reward: Sharpshooter’s Ventite."
         },
         {
           "id": "step-014",
@@ -109,6 +147,25 @@
     {
       "id": "figahl-icecaps",
       "title": "Figahl Icecaps",
+      "content": "## Figahl Icecaps — Frozen Awakening\n\nAfter escaping Titania, Velvet awakens on the frozen **Figahl Icecaps** with Rokurou and the eccentric witch **Magilou**. The icy landscape stretches before you, and this area serves as your first real exploration zone with proper item gathering and optional content.\n\n### Opening Battle\n\nImmediately upon regaining control, you’re thrown into combat against a **Werewolf** and **Eagle**. These enemies are aggressive but Velvet’s Therionization (Break Soul) makes quick work of them. Use it freely — there’s no penalty for overusing it in these early fights.\n\n<!-- checkpoint: figahl-wake | Awakened on Figahl Icecaps -->\n\n### Exploration & Items\n\nThe Figahl Icecaps is a relatively small area but has several collectibles scattered about:\n\n1. **320 Gald** — Turn around immediately after waking up; there’s a copper chest behind your starting position\n2. **Life Bottle** — Head north, then veer south to the upper level for a chest\n3. **Rosemary** — Field pickup on the left cliff as you head north (permanent stat boost herb)\n4. **Katz Box (Ten-Gallon Hat)** — Near the northern exit, after the Katz Souls tutorial\n\n<!-- checkpoint: figahl-items | Collected Figahl Icecaps items -->\n\n### Katz Boxes Tutorial\n\nPartway through the area, you’ll receive a tutorial about the **Katz Box** system. Shiny **Katz Souls** float around the overworld — collect them to spend at Katz Boxes scattered throughout the game. Your first box here costs a small amount and contains the **Ten-Gallon Hat** cosmetic accessory (equip via the Fashion menu, purely cosmetic).\n\n### The Laphicet Lookalike\n\nContinuing north triggers a cutscene where Velvet spots a young boy who looks remarkably like her deceased brother Laphicet. This is a Malak — a spiritual being enslaved by the Abbey. This encounter foreshadows major plot developments.\n\n<!-- checkpoint: figahl-laphicet-scene | Witnessed Laphicet lookalike cutscene -->\n\nAfter the cutscene, head right. Climb the vines before heading to town to collect a **Sage** herb (another permanent stat boost). Then descend and advance south to reach the port city of **Hellawes**.\n\n**Note:** There is one chest in this area that cannot be reached on your first visit. You can return later once you have the appropriate traversal ability — don’t stress about it now.\n\n<!-- checkpoint: figahl-exit | Reached Hellawes -->",
+      "checkpoints": [
+        {
+          "id": "figahl-wake",
+          "label": "Awakened on Figahl Icecaps"
+        },
+        {
+          "id": "figahl-items",
+          "label": "Collected Figahl Icecaps items"
+        },
+        {
+          "id": "figahl-laphicet-scene",
+          "label": "Witnessed Laphicet lookalike cutscene"
+        },
+        {
+          "id": "figahl-exit",
+          "label": "Reached Hellawes"
+        }
+      ],
       "steps": [
         {
           "id": "step-017",
@@ -124,17 +181,18 @@
         {
           "id": "step-019",
           "type": "collectible",
-          "text": "Collect **Rosemary** from the field pickup nearby."
+          "text": "Collect **Rosemary** from the field pickup nearby.",
+          "note": "Permanent stat boost herb — always grab these."
         },
         {
           "id": "step-020",
           "type": "collectible",
-          "text": "Open the chest for **320 Gald** shortly after waking up."
+          "text": "Open the chest for **320 Gald** — turn around from your starting position."
         },
         {
           "id": "step-021",
           "type": "note",
-          "text": "You'll receive a tutorial about **Katz Boxes** — collect shiny Katz Souls on the map to unlock them."
+          "text": "You’ll receive a tutorial about **Katz Boxes** — collect shiny Katz Souls on the map to unlock them."
         },
         {
           "id": "step-022",
@@ -150,18 +208,47 @@
         {
           "id": "step-024",
           "type": "collectible",
-          "text": "Collect **Sage** by climbing the vines before heading to town."
+          "text": "Collect **Sage** by climbing the vines before heading to town.",
+          "note": "Permanent stat boost herb."
         },
         {
           "id": "step-025",
           "type": "step",
           "text": "Descend and advance to reach **Hellawes**."
+        },
+        {
+          "id": "step-025b",
+          "type": "note",
+          "text": "One chest in this area is inaccessible on your first visit. Return later with the appropriate traversal ability."
         }
       ]
     },
     {
       "id": "hellawes-1",
       "title": "Hellawes (1st Visit)",
+      "content": "## Hellawes — Port City Under Abbey Control\n\n**Hellawes** is a northern port city firmly under the Abbey’s control. Velvet, Rokurou, and Magilou sneak in through a warehouse on the docks, staying hidden from the exorcists who patrol the streets. This is your first proper town with shops, NPCs, and side content.\n\n### Starting Warehouse\n\nYou begin in a warehouse on the docks. Before heading outside, thoroughly search the building:\n\n- **480 Gald** — In the middle of the storehouse\n- **Life Bottle** — Northwest corner of the storehouse\n- Various cooking ingredients scattered on the floor\n\n<!-- checkpoint: hellawes-warehouse | Explored the starting warehouse -->\n\n### Dock Area\n\nExit the warehouse and explore the dock area:\n\n- **Fire Ring** — Silver chest in the southeast dock corner (down the steps). **Equip this immediately** for fire resistance\n- **Life Bottle** — North part of the docks in a standard chest\n\nThe docks have several NPCs with green exclamation marks — talk to them for world-building dialogue and information about the Abbey’s activities in the region.\n\n<!-- checkpoint: hellawes-docks | Explored Hellawes docks -->\n\n### Town Proper & Rooftops\n\nHead into the main town area. Hellawes features accessible rooftops with valuable loot:\n\n- **Lavender** — On the northern rooftops (permanent stat boost)\n- **Amber Garment** — Chest on the rooftops accessed via ladders\n- **Blood Blade** — Gold chest at the end of the rooftops path (weapon for Rokurou)\n- **Amber Fragment** — Hidden area, down the steps from a halfway point on the rooftop\n- **Verbana** — Near the merchant’s guild archway (southwest exit area)\n\n<!-- checkpoint: hellawes-rooftops | Collected rooftop treasures -->\n\n### Story Progression\n\n1. **Visit the tavern** to hear about **Victoria**, a powerful Abbey member stationed in the region\n2. **Talk to Rokurou** to officially add him to your active party (he’ll be in combat now)\n3. **Magilou temporarily leaves** — she can be found lounging in the tavern but won’t rejoin the party yet\n\n### Shopping & Preparation\n\nVisit the shops to upgrade equipment. Key purchases:\n- Better weapons for both Velvet and Rokurou\n- Armor upgrades (check defense values carefully)\n- Stock up on Apple Gels and Life Bottles for the upcoming dungeon\n\n<!-- checkpoint: hellawes-shop | Purchased equipment upgrades -->\n\n**Skit:** Rest at the inn to trigger available skits. The Jacketless Outfit for Rokurou becomes available after resting.\n\nWhen you’re fully prepared, exit Hellawes toward **Beardsley** via the northern gate.\n\n<!-- checkpoint: hellawes-exit | Left Hellawes toward Beardsley -->",
+      "checkpoints": [
+        {
+          "id": "hellawes-warehouse",
+          "label": "Explored the starting warehouse"
+        },
+        {
+          "id": "hellawes-docks",
+          "label": "Explored Hellawes docks"
+        },
+        {
+          "id": "hellawes-rooftops",
+          "label": "Collected rooftop treasures"
+        },
+        {
+          "id": "hellawes-shop",
+          "label": "Purchased equipment upgrades"
+        },
+        {
+          "id": "hellawes-exit",
+          "label": "Left Hellawes toward Beardsley"
+        }
+      ],
       "steps": [
         {
           "id": "step-026",
@@ -188,7 +275,7 @@
           "id": "step-030",
           "type": "collectible",
           "text": "Find **Lavender** on the northern rooftops.",
-          "note": "Stat boost item — save for later or use now."
+          "note": "Permanent stat boost herb — always collect these."
         },
         {
           "id": "step-031",
@@ -198,7 +285,7 @@
         {
           "id": "step-032",
           "type": "collectible",
-          "text": "Pick up **Verbana** near the merchant's guild archway."
+          "text": "Pick up **Verbana** near the merchant’s guild archway."
         },
         {
           "id": "step-033",
@@ -218,12 +305,18 @@
         {
           "id": "step-036",
           "type": "note",
-          "text": "Magilou temporarily leaves — she can be found in the tavern but won't rejoin yet."
+          "text": "Magilou temporarily leaves — she can be found in the tavern but won’t rejoin yet."
         },
         {
           "id": "step-037",
           "type": "step",
-          "text": "Purchase equipment upgrades from the shop if needed."
+          "text": "Purchase equipment upgrades from the shop if needed.",
+          "note": "Prioritize weapons for Velvet and Rokurou."
+        },
+        {
+          "id": "step-037b",
+          "type": "step",
+          "text": "Rest at the inn to trigger skits and unlock the Jacketless Outfit for Rokurou."
         },
         {
           "id": "step-038",
@@ -235,6 +328,21 @@
     {
       "id": "beardsley",
       "title": "Beardsley",
+      "content": "## Beardsley — Small Village on the Frontier\n\n**Beardsley** is a small, quiet village nestled between Hellawes and the dangerous Hadlow Hollow cave system. The villagers here live in fear of a daemon named **Dyle** — a lizard-like creature that has been terrorizing the area. This brief town visit is primarily for story setup and restocking before the upcoming dungeon.\n\n### Arrival & NPCs\n\nUpon arriving, explore the village and talk to all NPCs (marked with green exclamation marks). Key information:\n\n- Villagers describe **Dyle**, a powerful daemon hiding in Hadlow Hollow\n- The Abbey has been unable (or unwilling) to deal with the daemon threat\n- Some NPCs hint at the cave’s layout and dangers\n\n<!-- checkpoint: beardsley-arrival | Arrived in Beardsley -->\n\n### Supplies & Preparation\n\nVisit the shop to stock up before Hadlow Hollow:\n\n- **Apple Gels** (at least 10) — healing is crucial in the upcoming dungeon\n- **Life Bottles** (at least 5) — the cave has tough enemies that can KO party members\n- **Panacea Bottles** — the cave enemies can inflict poison and paralysis\n- Any equipment upgrades available\n\n<!-- checkpoint: beardsley-shop | Stocked up on supplies -->\n\nThe enemies in Hadlow Hollow are a step up in difficulty from what you’ve faced so far. Make sure your equipment is current and you have adequate healing items.\n\n### Moving On\n\nWhen you’re ready, exit the village toward the north to enter **Hadlow Hollow**. Save at the save point near the exit — the cave has limited save opportunities inside.\n\n<!-- checkpoint: beardsley-exit | Headed to Hadlow Hollow -->",
+      "checkpoints": [
+        {
+          "id": "beardsley-arrival",
+          "label": "Arrived in Beardsley"
+        },
+        {
+          "id": "beardsley-shop",
+          "label": "Stocked up on supplies"
+        },
+        {
+          "id": "beardsley-exit",
+          "label": "Headed to Hadlow Hollow"
+        }
+      ],
       "steps": [
         {
           "id": "step-039",
@@ -244,23 +352,52 @@
         {
           "id": "step-040",
           "type": "step",
-          "text": "Talk to NPCs (green exclamation marks) for information about **Hadlow Hollow**."
+          "text": "Talk to NPCs (green exclamation marks) for information about **Hadlow Hollow** and the daemon Dyle."
         },
         {
           "id": "step-041",
           "type": "step",
-          "text": "Stock up on supplies at the shop before heading into the cave."
+          "text": "Stock up on supplies at the shop before heading into the cave.",
+          "note": "Buy Apple Gels, Life Bottles, and Panacea Bottles. Cave enemies inflict status ailments."
+        },
+        {
+          "id": "step-041b",
+          "type": "warning",
+          "text": "Hadlow Hollow enemies are significantly tougher than previous areas. Ensure equipment is upgraded."
         },
         {
           "id": "step-042",
           "type": "step",
-          "text": "Exit toward **Hadlow Hollow** when ready."
+          "text": "Exit toward **Hadlow Hollow** when ready. Save at the save point near the exit."
         }
       ]
     },
     {
       "id": "hadlow-hollow",
       "title": "Hadlow Hollow",
+      "content": "## Hadlow Hollow — Daemon’s Den\n\n**Hadlow Hollow** is a dark, daemon-infested cave system. This is your first proper dungeon with branching paths, hidden treasures, environmental hazards (tar pits), and multiple boss encounters. The daemon **Dyle** lurks in the depths, but you’ll also face the **Bat Baron** along the way.\n\n### Entrance & First Fork\n\nUpon entering, you’ll immediately encounter a fork:\n\n- **Northeast path:** Contains an Apple Gel — grab it first\n- **West path:** A chest with **500 Gald**\n\nHead west into a large area with roaming enemies. Practice Break Soul mechanics here — the enemies are good training dummies for extended combos.\n\n<!-- checkpoint: hadlow-entrance | Entered Hadlow Hollow -->\n\n### Mid-Dungeon Exploration\n\nThe cave is dark but relatively linear with short side branches:\n\n1. **Boulder interaction:** Smash a boulder blocking the northeast path to reveal a **Katz Box** ahead\n2. **Tar pit crossing:** Use stepping stones to cross safely — falling in damages your party\n3. **East room:** Pick up **Chamomile** (permanent stat boost herb)\n4. **Southwest loop:** Collect **Shadow Daggers** for Rokurou (solid weapon upgrade)\n\nPush a boulder into another tar pit to create a new path forward. This environmental puzzle mechanic appears throughout the dungeon.\n\n<!-- checkpoint: hadlow-midpoint | Reached the cave midpoint -->\n\n### Boss: Bat Baron\n\nMidway through the dungeon, you’ll face the **Bat Baron** — your first serious boss fight.\n\n- **HP:** 12,665\n- **Weakness:** Elemental Artes (resists neutral/physical attacks)\n- **Strategy:**\n  - Defeat the smaller bats first to reduce incoming damage\n  - Use Velvet’s elemental Artes (Swallow Dance is effective)\n  - Break Soul aggressively to maintain HP and extend combos\n  - Guard when the Baron charges its dive attack\n- **Reward:** Acrobat’s Ventite\n\n<!-- checkpoint: hadlow-bat-baron | Defeated the Bat Baron -->\n\nDon’t be discouraged if this takes a couple of attempts. If you’re struggling, return to the entrance to grind a level or two — the enemies respawn when you re-enter areas.\n\n### Deeper Passages\n\nAfter the Bat Baron:\n- Collect a **Life Bottle** from the chest ahead\n- A skit triggers — watch for character development\n- Pick up **Sage** (permanent stat boost)\n- Further ahead: **530 Gald** in a chest\n\n### Boss: Dyle\n\nAt the deepest point of the cave, you confront **Dyle** — the lizard daemon terrorizing Beardsley.\n\n- **HP:** 13,328\n- **Weakness:** Exploit Weak Point combos (the game introduces this mechanic here)\n- **Strategy:**\n  - Dyle has powerful tail swipe attacks — stay to his front or sides\n  - Use combos that target his elemental weakness\n  - Break Soul to recover when he lands heavy hits\n  - Keep healing items ready for his rage phase at low HP\n\n<!-- checkpoint: hadlow-dyle | Defeated Dyle -->\n\nAfter the fight, an important story scene plays. Velvet spares Dyle under certain conditions, and the party discusses their next move. This is also where the party’s path toward rescuing **Laphicet** (the Malak boy) becomes clear.\n\n### Exiting the Cave\n\nLoop around collecting any treasures you missed, then exit Hadlow Hollow. Your next destination is back to **Hellawes** for a confrontation with the Abbey.\n\n<!-- checkpoint: hadlow-exit | Exited Hadlow Hollow -->",
+      "checkpoints": [
+        {
+          "id": "hadlow-entrance",
+          "label": "Entered Hadlow Hollow"
+        },
+        {
+          "id": "hadlow-midpoint",
+          "label": "Reached the cave midpoint"
+        },
+        {
+          "id": "hadlow-bat-baron",
+          "label": "Defeated the Bat Baron"
+        },
+        {
+          "id": "hadlow-dyle",
+          "label": "Defeated Dyle"
+        },
+        {
+          "id": "hadlow-exit",
+          "label": "Exited Hadlow Hollow"
+        }
+      ],
       "steps": [
         {
           "id": "step-043",
@@ -273,15 +410,46 @@
           "text": "Explore all side paths before progressing — several chests are easy to miss in the dark."
         },
         {
+          "id": "step-044b",
+          "type": "collectible",
+          "text": "Collect **500 Gald** from the west path and **Apple Gel** from the northeast at the first fork."
+        },
+        {
+          "id": "step-044c",
+          "type": "collectible",
+          "text": "Open the **Katz Box** after smashing the boulder on the northeast path."
+        },
+        {
+          "id": "step-044d",
+          "type": "collectible",
+          "text": "Pick up **Chamomile** in the east room and **Shadow Daggers** (Rokurou weapon) from the southwest loop."
+        },
+        {
           "id": "step-045",
           "type": "step",
-          "text": "Follow the linear cave path, defeating enemies and collecting items along the way."
+          "text": "Follow the cave path, pushing boulders into tar pits to create new paths forward."
+        },
+        {
+          "id": "step-045b",
+          "type": "boss",
+          "text": "**BOSS: Bat Baron** — HP: 12,665. Resists physical; use elemental Artes.",
+          "note": "Defeat smaller bats first. Use Swallow Dance and Break Soul aggressively. Reward: Acrobat’s Ventite."
+        },
+        {
+          "id": "step-045c",
+          "type": "collectible",
+          "text": "After the Bat Baron, collect a **Life Bottle**, **Sage**, and **530 Gald** from chests ahead."
         },
         {
           "id": "step-046",
+          "type": "boss",
+          "text": "**BOSS: Dyle** — HP: 13,328. Exploit Weak Point combos introduced in this fight.",
+          "note": "Stay to his front/sides to avoid tail swipes. Heal through his rage phase at low HP."
+        },
+        {
+          "id": "step-046b",
           "type": "step",
-          "text": "Rescue **Laphicet** (the Malak boy) in the depths of the cave.",
-          "note": "He joins your party after this scene."
+          "text": "Watch the story scene after defeating Dyle. Velvet spares him and the party regroups."
         },
         {
           "id": "step-047",
@@ -293,6 +461,25 @@
     {
       "id": "hellawes-2",
       "title": "Hellawes (2nd Visit)",
+      "content": "## Hellawes (2nd Visit) — Confrontation with Teresa\n\nReturning to Hellawes triggers a major boss confrontation. The Abbey’s exorcist **Teresa Linares** has set a trap for Velvet’s group. This visit is combat-heavy and marks the point where Laphicet officially joins as a permanent party member.\n\n### Pre-Battle Warning\n\n<!-- checkpoint: hellawes2-prep | Prepared for Teresa fight -->\n\n**Prepare your party before entering the city.** A boss fight triggers automatically upon arrival:\n- Equip the best available gear on all party members\n- Ensure you have at least 10 Apple Gels and 5 Life Bottles\n- Set up your Arte configurations for maximum damage output\n- Consider equipping water resistance if available\n\n### Boss: Teresa Linares\n\n**Teresa** confronts the party with two tethered **Malakhim** supporting her.\n\n- **HP:** 6,664\n- **Supported by:** Two Malakhim (linked to boost her stats)\n- **Element:** Water/Physical focused attacks\n- **Strategy:**\n  1. **Focus on defeating the Malakhim first** — they continuously boost Teresa’s attack and defense\n  2. Once the Malakhim fall, Teresa becomes significantly weaker\n  3. Use Velvet to corner Teresa against walls for extended combos\n  4. Guard through her fast sword strikes — she has deceptive range\n  5. Break Soul to heal through her water-elemental AoE attacks\n\n<!-- checkpoint: hellawes2-teresa | Defeated Teresa -->\n\nAfter the battle, important cutscenes play. **Laphicet** (the Malak boy spotted earlier) officially joins your party as a permanent member. He functions as your primary healer and ranged attacker — a crucial addition to the team.\n\n### Post-Battle Activities\n\nWith Teresa defeated and Laphicet in your party:\n\n1. **Restock at shops** — replace used healing items\n2. **Rest at the inn** for skits — rest **twice** to trigger all available skits\n3. **Equip Laphicet** — check his weapon, armor, and accessories\n4. **Set Laphicet’s strategy** — configure him as a healer in the party strategy menu\n\n<!-- checkpoint: hellawes2-restock | Restocked and rested -->\n\n### Leaving Hellawes\n\nWhen fully prepared, exit Hellawes toward the **West Laban Tunnel** — your path south toward the mainland.\n\n<!-- checkpoint: hellawes2-exit | Left toward West Laban Tunnel -->",
+      "checkpoints": [
+        {
+          "id": "hellawes2-prep",
+          "label": "Prepared for Teresa fight"
+        },
+        {
+          "id": "hellawes2-teresa",
+          "label": "Defeated Teresa"
+        },
+        {
+          "id": "hellawes2-restock",
+          "label": "Restocked and rested"
+        },
+        {
+          "id": "hellawes2-exit",
+          "label": "Left toward West Laban Tunnel"
+        }
+      ],
       "steps": [
         {
           "id": "step-048",
@@ -303,12 +490,22 @@
           "id": "step-049",
           "type": "boss",
           "text": "**BOSS: Teresa** — HP: 6,664. Supported by two tethered Malakhim.",
-          "note": "Focus on defeating the Malakhim first — they boost Teresa's stats. Use Velvet to corner her."
+          "note": "Focus on defeating the Malakhim first — they boost Teresa’s stats. Use Velvet to corner her."
+        },
+        {
+          "id": "step-049b",
+          "type": "note",
+          "text": "**Laphicet** permanently joins your party after this battle. He serves as your primary healer and ranged attacker."
         },
         {
           "id": "step-050",
           "type": "step",
           "text": "After defeating Teresa, watch the story cutscenes."
+        },
+        {
+          "id": "step-050b",
+          "type": "step",
+          "text": "Open the party menu and fully equip Laphicet (weapon, armor, accessories)."
         },
         {
           "id": "step-051",
@@ -326,6 +523,25 @@
     {
       "id": "west-laban-tunnel",
       "title": "West Laban Tunnel",
+      "content": "## West Laban Tunnel — Underground Passage South\n\nThe **West Laban Tunnel** connects the northern region (Hellawes area) to the southern mainland. This cave dungeon features branching paths, environmental hazards, and enemies that can inflict troublesome status ailments. With Laphicet in your party, you now have a proper four-member team.\n\n### Enemies & Hazards\n\nCommon enemies in this area:\n- **Rogue Rats** — fast, attack in groups\n- **Ant-Lions** — earth-elemental, can cause paralysis\n- **Bat-type Daemons** — flying enemies, harder to combo\n- **Water Elementals** — magic-focused, stay at range\n\n**Status ailments** (Poison and Paralysis) are common here. Equip accessories that resist these, or keep Panacea Bottles ready.\n\n<!-- checkpoint: laban-entrance | Entered West Laban Tunnel -->\n\n### Exploration\n\nThe tunnel is fairly linear but has several hidden nooks and side corridors:\n\n**Entrance area:**\n- **Life Bottle** — Basic chest near the entrance\n- **Apple Gel** — Sparkle point on the ground\n\n**First fork (left path):**\n- **Amber Fragment** — Chest behind a breakable wall\n- Search for sparkle points along the walls\n\n**Water channel room (west):**\n- **Verbena** — Hidden in a nook (permanent stat boost)\n- Cross the rope bridge area for an **Amber Garment** chest\n\n**Large circular room:**\n- **Drop Earring** — Chest on a raised platform (requires jumping from the upper path)\n- **Life Bottle** — Along the outer edge\n\n<!-- checkpoint: laban-treasures | Collected tunnel treasures -->\n\n### Katz Box\n\nA **Katz Box** is located in a side passage in the central tunnel area. It requires **15 Katz Spirits** to open and typically contains a Katz Costume cosmetic item.\n\n### Lower Flooded Cavern\n\nThe lower section has flooded passages:\n- **Panacea Bottle** — In a side alcove\n- **Lavender** — Dead end sparkle (permanent stat boost)\n- **Amber Belt** — Box in a side alcove near the save point\n\n<!-- checkpoint: laban-lower | Cleared the lower cavern -->\n\n### Exit\n\nAfter exploring thoroughly, continue through to the tunnel exit. The path leads to the **Burnack Plateau** — an open area with views of the sea and the fortress of Vortigern in the distance.\n\n<!-- checkpoint: laban-exit | Exited to Burnack Plateau -->",
+      "checkpoints": [
+        {
+          "id": "laban-entrance",
+          "label": "Entered West Laban Tunnel"
+        },
+        {
+          "id": "laban-treasures",
+          "label": "Collected tunnel treasures"
+        },
+        {
+          "id": "laban-lower",
+          "label": "Cleared the lower cavern"
+        },
+        {
+          "id": "laban-exit",
+          "label": "Exited to Burnack Plateau"
+        }
+      ],
       "steps": [
         {
           "id": "step-053",
@@ -333,9 +549,35 @@
           "text": "Enter the West Laban Tunnel and fight through enemy encounters."
         },
         {
+          "id": "step-053b",
+          "type": "warning",
+          "text": "Enemies here inflict Poison and Paralysis. Equip resistance accessories or keep Panacea Bottles ready."
+        },
+        {
+          "id": "step-053c",
+          "type": "collectible",
+          "text": "Collect **Life Bottle** and **Apple Gel** near the entrance."
+        },
+        {
+          "id": "step-053d",
+          "type": "collectible",
+          "text": "Find the **Amber Fragment** behind a breakable wall on the left fork."
+        },
+        {
           "id": "step-054",
           "type": "step",
-          "text": "Explore side paths for treasure chests — the tunnel has several branches."
+          "text": "Explore side paths for treasure chests — the tunnel has several branches.",
+          "note": "Check the rope bridge area for an Amber Garment and the raised platform for a Drop Earring."
+        },
+        {
+          "id": "step-054b",
+          "type": "collectible",
+          "text": "Open the **Katz Box** in the central tunnel side passage (costs 15 Katz Spirits)."
+        },
+        {
+          "id": "step-054c",
+          "type": "collectible",
+          "text": "Collect **Verbena**, **Lavender**, and **Amber Belt** from the lower flooded section."
         },
         {
           "id": "step-055",
@@ -347,6 +589,25 @@
     {
       "id": "burnack-plateau",
       "title": "Burnack Plateau",
+      "content": "## Burnack Plateau — Open Fields Before Vortigern\n\nThe **Burnack Plateau** is a wide-open area between the West Laban Tunnel and the fortress of **Vortigern**. After the confined tunnels, this area offers sweeping views of the coastline and distant landmarks. It’s also an excellent grinding spot if your party is underleveled.\n\n### Arrival\n\nExiting the West Laban Tunnel, jump down the cliffs to descend to the plateau floor. A cutscene plays showing the massive wall of **Vortigern** in the distance — your next major objective.\n\n<!-- checkpoint: burnack-arrival | Arrived at Burnack Plateau -->\n\n### Exploration & Items\n\nThe plateau is relatively straightforward but has items along its paths:\n\n- **Verbena** — On the cliff path during descent (permanent stat boost)\n- **Life Bottle** — Chest near the river at the bottom\n- Several Katz Souls floating in the open fields\n- Side paths lead to additional sparkle items\n\nThe enemies here are moderate in difficulty — a good balance for your current party level. If you’re finding upcoming content difficult, spend some time fighting here.\n\n<!-- checkpoint: burnack-items | Collected plateau items -->\n\n### Grinding Opportunity\n\nThis area is recommended for level grinding because:\n- Enemies give decent XP relative to time investment\n- The save point is nearby for HP restoration\n- Enemy variety helps you practice different combat strategies\n- Equipment mastery progresses quickly with frequent battles\n\nAim for around **level 18–20** before attempting Vortigern if you’re struggling.\n\n### Party Setup\n\nWith a full four-member party (Velvet, Rokurou, Magilou, Laphicet), this is a good time to:\n- Experiment with different party formations\n- Set up AI strategies for each character\n- Practice Switch Blast timing\n- Configure Arte shortcut loadouts\n\n<!-- checkpoint: burnack-grinding | Leveled up on the plateau -->\n\n### Moving Forward\n\nContinue east along the main path toward **Vortigern**. You’ll encounter **Eizen** here — a Malak and first mate of the pirate ship Van Eltia. A cutscene introduces him and his plan to help your party breach the Vortigern fortress.\n\n<!-- checkpoint: burnack-exit | Headed to Vortigern -->",
+      "checkpoints": [
+        {
+          "id": "burnack-arrival",
+          "label": "Arrived at Burnack Plateau"
+        },
+        {
+          "id": "burnack-items",
+          "label": "Collected plateau items"
+        },
+        {
+          "id": "burnack-grinding",
+          "label": "Leveled up on the plateau"
+        },
+        {
+          "id": "burnack-exit",
+          "label": "Headed to Vortigern"
+        }
+      ],
       "steps": [
         {
           "id": "step-056",
@@ -354,44 +615,109 @@
           "text": "Cross the open plateau area, fighting enemies along the paths."
         },
         {
+          "id": "step-056b",
+          "type": "collectible",
+          "text": "Collect **Verbena** on the cliff descent and a **Life Bottle** from the chest near the river."
+        },
+        {
           "id": "step-057",
           "type": "note",
-          "text": "This is a good area to grind levels if you're underleveled for upcoming fights."
+          "text": "This is a good area to grind levels if you’re underleveled for upcoming fights. Aim for level 18–20."
         },
         {
           "id": "step-058",
           "type": "step",
-          "text": "Explore side paths for collectibles and Katz Boxes."
+          "text": "Explore side paths for collectibles and Katz Souls."
+        },
+        {
+          "id": "step-058b",
+          "type": "note",
+          "text": "Good time to experiment with party strategies and Arte configurations for the full 4-member team."
         },
         {
           "id": "step-059",
           "type": "step",
-          "text": "Continue east toward **Vortigern**."
+          "text": "Continue east toward **Vortigern**. Meet **Eizen** in a story cutscene."
         }
       ]
     },
     {
       "id": "vortigern",
       "title": "Vortigern",
+      "content": "## Vortigern — Fortress Infiltration\n\n**Vortigern** is a massive fortress that controls sea passage between the northern and southern regions. The party must infiltrate it from the land side and open the sea gates so the pirate ship **Van Eltia** can pass through. **Eizen**, a Malak and the ship’s first mate, joins your party permanently for this mission.\n\n### Meeting Eizen\n\nBefore entering the fortress, Eizen (known as \"The Reaper\" due to his cursed luck) explains the plan:\n- The front gate is protected by a barrier — you can’t enter directly\n- Instead, approach from the less-defended left side entrance\n- Fight through the interior, reach the upper floors, and activate the gate switches\n- The Van Eltia will sail through once the gates open\n\n<!-- checkpoint: vortigern-eizen | Eizen joined the party -->\n\n**Eizen permanently joins the party** after this scene. He’s a powerful physical brawler with earth-elemental Artes and excellent stagger potential. Equip him immediately.\n\n### Entering the Fortress\n\nHead left to find the less-defended entrance. The guards here transform into daemons — defeat them to enter. Inside, Vortigern is a winding, multi-level fortress filled with soldiers and daemons.\n\n### Fortress Interior\n\nNavigate through the fortress corridors:\n- **Ground floor:** Linear path with guard encounters. Check side rooms for items\n- **Earth Ring** — Chest in a side room on the ground floor\n- **Life Bottles** — Multiple chests scattered throughout\n- Use vines and windows to bypass locked doors when available\n- **Verbena, Lavender** — Herb pickups along the path\n\n<!-- checkpoint: vortigern-interior | Explored fortress interior -->\n\n### Boss: Longsword Praetor\n\nMidway through the fortress, you face the **Longsword Praetor** with two summoned Malakhim.\n\n- **Strategy:** Take out the Malak links first to weaken the Praetor, then focus all damage on him\n- Use Eizen’s heavy stagger attacks to interrupt the Praetor’s combos\n- Laphicet should focus on healing the party\n\n<!-- checkpoint: vortigern-praetor | Defeated the Longsword Praetor -->\n\n### Opening the Gates\n\nAfter the boss:\n1. Return to the central room\n2. Use newly accessible paths to reach the gate lever controls\n3. Activate the levers to open the sea gates\n4. The Van Eltia sails through during a cutscene\n5. Fight a giant daemonized guard during the escape sequence\n\n<!-- checkpoint: vortigern-gates | Opened the sea gates -->\n\n### Escape & Boarding the Van Eltia\n\nAfter opening the gates and defeating the final guard, the party escapes to the Van Eltia. Important story moments:\n- **Laphicet officially receives his name** from Velvet during this sequence\n- The party is now fully assembled for the journey south\n- The Van Eltia becomes your mobile base for fast travel\n\n### On the Van Eltia\n\nExplore the ship for items and talk to all party members for skits:\n- Check the cabins for equipment and items\n- Talk to the pirate crew members for world-building\n- Access **Expeditions** — a mini-game unlocked on the ship\n- The ship’s shop has new equipment available\n\n<!-- checkpoint: vortigern-ship | Boarded the Van Eltia -->\n\nSet sail toward **Port Zekson** when ready.",
+      "checkpoints": [
+        {
+          "id": "vortigern-eizen",
+          "label": "Eizen joined the party"
+        },
+        {
+          "id": "vortigern-interior",
+          "label": "Explored fortress interior"
+        },
+        {
+          "id": "vortigern-praetor",
+          "label": "Defeated the Longsword Praetor"
+        },
+        {
+          "id": "vortigern-gates",
+          "label": "Opened the sea gates"
+        },
+        {
+          "id": "vortigern-ship",
+          "label": "Boarded the Van Eltia"
+        }
+      ],
       "steps": [
         {
           "id": "step-060",
           "type": "step",
-          "text": "Board the pirate ship **Van Eltia** and meet the crew."
+          "text": "Meet Eizen and learn the infiltration plan for Vortigern fortress."
+        },
+        {
+          "id": "step-060b",
+          "type": "note",
+          "text": "**Eizen permanently joins the party.** Equip him immediately — he’s a powerful physical brawler with earth Artes."
+        },
+        {
+          "id": "step-060c",
+          "type": "step",
+          "text": "Enter the fortress through the left side entrance after defeating the daemon guards."
         },
         {
           "id": "step-061",
           "type": "step",
-          "text": "Watch cutscenes introducing **Eizen** and the crew.",
-          "note": "Eizen permanently joins the party after these scenes."
+          "text": "Navigate through the fortress interior, collecting items and fighting enemies.",
+          "note": "Check side rooms for Earth Ring, Life Bottles, and herb pickups."
+        },
+        {
+          "id": "step-061b",
+          "type": "boss",
+          "text": "**BOSS: Longsword Praetor** — Supported by two Malakhim.",
+          "note": "Defeat Malak links first to weaken the Praetor. Use Eizen’s stagger attacks."
         },
         {
           "id": "step-062",
           "type": "step",
-          "text": "Explore the ship for items and talk to all party members for skits."
+          "text": "Activate the gate lever controls to open the sea gates for the Van Eltia."
+        },
+        {
+          "id": "step-062b",
+          "type": "step",
+          "text": "Defeat the giant daemonized guard during the escape sequence."
+        },
+        {
+          "id": "step-062c",
+          "type": "note",
+          "text": "**Laphicet officially receives his name** from Velvet during the escape. Major story moment."
         },
         {
           "id": "step-063",
+          "type": "step",
+          "text": "Explore the Van Eltia — talk to party members for skits, check cabins for items.",
+          "note": "Expeditions mini-game unlocks here. Ship shop has new equipment."
+        },
+        {
+          "id": "step-063b",
           "type": "step",
           "text": "Set sail toward **Port Zekson**."
         }
@@ -400,6 +726,25 @@
     {
       "id": "port-zekson",
       "title": "Port Zekson",
+      "content": "## Port Zekson — Southern Harbor Town\n\n**Port Zekson** is the first major town on the southern continent. After the long journey from the frozen north, this bustling port offers new shops, side content, and story developments. The Abbey’s presence is strong here, adding tension to your exploration.\n\n### Arrival\n\nDisembark from the Van Eltia and watch the arrival cutscenes. The party discusses their next moves and objectives — primarily tracking down information about **Artorius** and the Abbey’s plans.\n\n<!-- checkpoint: zekson-arrival | Arrived at Port Zekson -->\n\n### Town Exploration\n\nExplore the port thoroughly:\n\n**Dock Area:**\n- **Apple Gel** — Bronze chest near the ship\n- **Chocolate Idol** (Magilou equipment) — Silver chest left of the south exit\n- Talk to the pirate by the Van Eltia for a bonus skit\n\n**Town Proper:**\n- Various NPCs provide information about the Abbey’s activities\n- Green exclamation mark NPCs have important dialogue\n- Several cooking ingredients available from sparkle points\n\n<!-- checkpoint: zekson-explore | Explored Port Zekson -->\n\n### Shopping\n\nVisit the weapons vendor for significant upgrades:\n- New weapons available for all party members (including Eizen)\n- Armor improvements over anything found in the north\n- Stock up on healing items for the road ahead\n- Sell spare equipment and materials for Gald\n\n### Inn & Skits\n\nRest at the inn to trigger available skits. These provide:\n- Character development between party members\n- Hints about upcoming story events\n- Worldbuilding about the southern continent\n\n<!-- checkpoint: zekson-rest | Rested and watched skits -->\n\n### Moving On\n\nWhen you’ve finished shopping and exploring, exit Port Zekson toward the **Danann Highway** — the main road leading to the capital city of Loegres.\n\n<!-- checkpoint: zekson-exit | Left toward Danann Highway -->",
+      "checkpoints": [
+        {
+          "id": "zekson-arrival",
+          "label": "Arrived at Port Zekson"
+        },
+        {
+          "id": "zekson-explore",
+          "label": "Explored Port Zekson"
+        },
+        {
+          "id": "zekson-rest",
+          "label": "Rested and watched skits"
+        },
+        {
+          "id": "zekson-exit",
+          "label": "Left toward Danann Highway"
+        }
+      ],
       "steps": [
         {
           "id": "step-064",
@@ -407,14 +752,25 @@
           "text": "Arrive at Port Zekson and explore the port town."
         },
         {
+          "id": "step-064b",
+          "type": "collectible",
+          "text": "Collect **Apple Gel** from the bronze chest near the ship."
+        },
+        {
+          "id": "step-064c",
+          "type": "collectible",
+          "text": "Open the silver chest left of the south exit for the **Chocolate Idol** (Magilou equipment)."
+        },
+        {
           "id": "step-065",
           "type": "step",
-          "text": "Talk to NPCs and gather information about the **Abbey's** presence."
+          "text": "Talk to NPCs and gather information about the **Abbey’s** presence."
         },
         {
           "id": "step-066",
           "type": "step",
-          "text": "Visit shops to upgrade equipment for the party."
+          "text": "Visit shops to upgrade equipment for the party.",
+          "note": "Significant upgrades available for all party members including Eizen."
         },
         {
           "id": "step-067",
@@ -431,6 +787,21 @@
     {
       "id": "danann-highway",
       "title": "Danann Highway",
+      "content": "## Danann Highway — Road to the Capital\n\nThe **Danann Highway** is the main road connecting Port Zekson to the imperial capital of **Loegres**. It’s a wide, open area with rolling fields, scattered enemies, and plenty of hidden items off the beaten path. The scenery shifts from coastal to inland as you progress.\n\n### Route Overview\n\nThe highway runs roughly north-south with several side areas branching off. Take your time exploring — the detours contain valuable equipment and permanent stat-boosting herbs.\n\n<!-- checkpoint: danann-start | Started traversing Danann Highway -->\n\n### Items & Collectibles\n\n**Northeast corner (open area):**\n- **Calcite Waistcoat** — Armor for male characters (good defense upgrade)\n\n**Southeast path:**\n- **Katz Box** — Hidden behind a large tree\n- **Chamomile** — Herb pickup nearby (permanent stat boost)\n\n**Eastern detour:**\n- **Rosemary** — Permanent stat boost herb\n\n**Northern side path:**\n- **750 Gald** — Chest at the end of a dead-end path\n\n**Western area:**\n- **Earth Ring** — Accessory providing earth resistance\n\n<!-- checkpoint: danann-items | Collected highway items -->\n\n### Enemies\n\nEnemies along the highway are moderate difficulty — slightly tougher than Burnack Plateau but not as dangerous as dungeon encounters. They provide good experience for maintaining appropriate levels before Loegres.\n\nWatch for:\n- Groups that can surround your party in the open fields\n- Flying enemies that require aerial-targeting Artes\n- Occasional stronger \"elite\" enemies that roam fixed paths\n\n### Approaching Loegres\n\nAs you near the end of the highway, the capital city of **Loegres** becomes visible in the distance — a massive walled city that serves as the seat of the Holy Midgand Empire and the Abbey’s power center.\n\n<!-- checkpoint: danann-exit | Reached Loegres -->",
+      "checkpoints": [
+        {
+          "id": "danann-start",
+          "label": "Started traversing Danann Highway"
+        },
+        {
+          "id": "danann-items",
+          "label": "Collected highway items"
+        },
+        {
+          "id": "danann-exit",
+          "label": "Reached Loegres"
+        }
+      ],
       "steps": [
         {
           "id": "step-069",
@@ -438,9 +809,25 @@
           "text": "Traverse the highway fighting enemies along the road."
         },
         {
+          "id": "step-069b",
+          "type": "collectible",
+          "text": "Find the **Calcite Waistcoat** in the northeast corner of the open area."
+        },
+        {
+          "id": "step-069c",
+          "type": "collectible",
+          "text": "Open the **Katz Box** behind the big tree and collect **Chamomile** nearby."
+        },
+        {
           "id": "step-070",
           "type": "step",
-          "text": "Explore side paths and open fields for hidden chests."
+          "text": "Explore side paths and open fields for hidden chests.",
+          "note": "Detour east for Rosemary, north for 750 Gald, and west for an Earth Ring."
+        },
+        {
+          "id": "step-070b",
+          "type": "collectible",
+          "text": "Collect **Rosemary** (east), **750 Gald** (north), and **Earth Ring** (west) from detour paths."
         },
         {
           "id": "step-071",
@@ -452,6 +839,29 @@
     {
       "id": "loegres-1",
       "title": "Loegres (1st Visit)",
+      "content": "## Loegres — Capital of the Holy Midgand Empire\n\n**Loegres** is the largest city in the game and the seat of power for both the Holy Midgand Empire and the Abbey. This sprawling capital has multiple districts, numerous shops with significantly better equipment, side quests, and important story triggers. Plan to spend considerable time here.\n\n### Arrival\n\nEntering Loegres triggers cutscenes establishing the political situation. The Abbey’s influence is everywhere — exorcists patrol the streets and propaganda promotes Artorius as a hero. Your party must move carefully.\n\n<!-- checkpoint: loegres-arrival | Arrived in Loegres -->\n\n### City Exploration\n\n**Near the entrance:**\n- Sub-events available (look for exclamation marks)\n- Start of \"Magilou’s Menagerie in Motion\" skit series\n\n**By the Weapon Shop:**\n- **Amber Paper** — Chest near the shop entrance\n\n**Tavern area:**\n- Speak to **Tabatha** to advance the main story\n- \"Search for a Missing Man\" side quest begins here\n- Code Red bounties available from the board\n\n### Bloodwing Quests\n\nVisit the guild to unlock **Bloodwing Quests** — these are bounty board side quests that send you to defeat specific powerful enemies. Rewards include:\n- Rare equipment\n- Unique materials\n- Significant Gald payouts\n- New quests unlock as you progress the story\n\n<!-- checkpoint: loegres-guild | Unlocked Bloodwing Quests -->\n\n### Shopping\n\nLoegres shops have **significantly better gear** than anything available previously:\n- New weapon tiers for all party members\n- Major armor upgrades\n- Powerful accessories\n- Crafting materials\n\nSpend your Gald here — the power jump is substantial and will help considerably in upcoming dungeons.\n\n<!-- checkpoint: loegres-shops | Upgraded equipment -->\n\n### Inn & Skits\n\nRest at the inn to trigger multiple skits:\n- Party interactions about being in the capital\n- Reactions to the Abbey’s propaganda\n- Character backstory revelations\n- Hints about upcoming objectives\n\n### Story Progression\n\nAfter exploring and shopping:\n1. Speak to Tabatha in the tavern\n2. Return to the docks for a plot scene\n3. The party’s objectives become clear — investigate the **Barona Catacombs** beneath the city\n\n<!-- checkpoint: loegres-story | Story objectives set -->\n\nWhen the story objectives are established, head to the **Barona Catacombs** entrance (accessible from the cathedral area).\n\n<!-- checkpoint: loegres-catacombs | Headed to Barona Catacombs -->",
+      "checkpoints": [
+        {
+          "id": "loegres-arrival",
+          "label": "Arrived in Loegres"
+        },
+        {
+          "id": "loegres-guild",
+          "label": "Unlocked Bloodwing Quests"
+        },
+        {
+          "id": "loegres-shops",
+          "label": "Upgraded equipment"
+        },
+        {
+          "id": "loegres-story",
+          "label": "Story objectives set"
+        },
+        {
+          "id": "loegres-catacombs",
+          "label": "Headed to Barona Catacombs"
+        }
+      ],
       "steps": [
         {
           "id": "step-072",
@@ -464,20 +874,31 @@
           "text": "Explore the city and talk to NPCs for information about **Artorius** and the Abbey."
         },
         {
+          "id": "step-073b",
+          "type": "collectible",
+          "text": "Find the **Amber Paper** in the chest near the weapon shop."
+        },
+        {
           "id": "step-074",
           "type": "step",
           "text": "Visit the guild to unlock **Bloodwing Quests** (bounty board side quests).",
-          "note": "These provide good rewards and unlock over time."
+          "note": "These provide rare equipment, materials, and Gald. New quests unlock as you progress."
         },
         {
           "id": "step-075",
           "type": "step",
-          "text": "Upgrade equipment at the Loegres shops — they have significantly better gear."
+          "text": "Upgrade equipment at the Loegres shops — they have significantly better gear.",
+          "note": "Major power jump available here. Spend your Gald on weapon and armor upgrades for all members."
         },
         {
           "id": "step-076",
           "type": "step",
           "text": "Rest at the inn and watch all available skits."
+        },
+        {
+          "id": "step-076b",
+          "type": "step",
+          "text": "Speak to Tabatha in the tavern and return to the docks to advance the story."
         },
         {
           "id": "step-077",
@@ -489,11 +910,30 @@
     {
       "id": "barona-catacombs",
       "title": "Barona Catacombs",
+      "content": "## Barona Catacombs — Beneath the Capital\n\nThe **Barona Catacombs** are an extensive underground network beneath Loegres. This dungeon features lever-based water drainage puzzles, tight corridors with ambush encounters, a challenging Code Red boss, and valuable treasures hidden throughout the flooded passages.\n\n### Entrance\n\nSpeak to the soldier in the red scarf at the cathedral area in Loegres to gain access. A brief dialogue scene plays before you descend into the catacombs.\n\n<!-- checkpoint: catacombs-entrance | Entered the Barona Catacombs -->\n\n### Water Drainage Puzzles\n\nThe catacombs use a **lever-based drainage system** — pulling levers drains water from specific sections, opening new paths:\n\n1. **First lever (south):** Drains the initial flooded area\n2. Head east after draining for a **Verbena** herb\n3. Continue south for a skit trigger and **Apple Gel** in the large room\n4. Break the boulder blocking the next passage and grab a **Life Bottle**\n\n### Mid-Dungeon Exploration\n\n- Crawl through the eastern tunnel\n- **Fork paths:** East leads to the Code Red boss, south continues the main path\n- Collect **Wind Ring** after using another drainage lever\n- Head upstairs for a **Katz Box**\n- Southwest route: **Lavender** (permanent stat boost)\n- Southeast: **Calcite Fragment**\n\n<!-- checkpoint: catacombs-puzzles | Solved drainage puzzles -->\n\n### Code Red Boss: Pillbug\n\nIn the eastern tunnels, you’ll encounter the **Pillbug** — a Code Red monster boss.\n\n- **HP:** 21,581\n- **Weakness:** Wind\n- **Attacks:** Paralyzing non-elemental strikes that can break your Blast Souls gauge\n- **Strategy:**\n  - Use Wind-based Artes (Eizen’s earth won’t help here — rely on Velvet and Magilou)\n  - Avoid his spinning moves — they have wide AoE\n  - Manage your gauge carefully — Pillbug specifically targets it\n  - Keep healing consistent; this is the toughest Code Red so far\n  - Be patient — this is a war of attrition\n\n<!-- checkpoint: catacombs-pillbug | Defeated Pillbug (Code Red) -->\n\n### Final Section\n\nAfter the Pillbug (or bypassing him if you prefer to return later):\n- Use the final lever to drain the last water section\n- Head southwest through a crawl tunnel\n- Collect **880 Gald** from the chest at the end\n- The exit leads toward the **Loegres Villa**\n\n<!-- checkpoint: catacombs-exit | Completed Barona Catacombs -->\n\n### Returning to Loegres\n\nAfter completing the catacombs, briefly return to Loegres to:\n- Restock healing items\n- Save your progress\n- Watch any newly available skits at the inn",
+      "checkpoints": [
+        {
+          "id": "catacombs-entrance",
+          "label": "Entered the Barona Catacombs"
+        },
+        {
+          "id": "catacombs-puzzles",
+          "label": "Solved drainage puzzles"
+        },
+        {
+          "id": "catacombs-pillbug",
+          "label": "Defeated Pillbug (Code Red)"
+        },
+        {
+          "id": "catacombs-exit",
+          "label": "Completed Barona Catacombs"
+        }
+      ],
       "steps": [
         {
           "id": "step-078",
           "type": "step",
-          "text": "Enter the catacombs and navigate the underground passages."
+          "text": "Enter the catacombs via the cathedral area (speak to the soldier in the red scarf)."
         },
         {
           "id": "step-079",
@@ -501,9 +941,31 @@
           "text": "The catacombs have dead-end paths with strong enemies — save frequently."
         },
         {
+          "id": "step-079b",
+          "type": "step",
+          "text": "Pull the first lever (south) to drain the flooded area and open new paths."
+        },
+        {
+          "id": "step-079c",
+          "type": "collectible",
+          "text": "Collect **Verbena** (east), **Apple Gel** (south room), and **Life Bottle** (past the boulder)."
+        },
+        {
           "id": "step-080",
           "type": "step",
-          "text": "Explore all branches for treasure chests and equipment."
+          "text": "Explore all branches for treasure chests and equipment.",
+          "note": "Find the Wind Ring, Katz Box (upstairs), Lavender (southwest), and Calcite Fragment (southeast)."
+        },
+        {
+          "id": "step-080b",
+          "type": "boss",
+          "text": "**CODE RED BOSS: Pillbug** — HP: 21,581. Weak to Wind.",
+          "note": "Paralyzing attacks that break Blast Souls gauge. Use Wind Artes and be patient — war of attrition."
+        },
+        {
+          "id": "step-080c",
+          "type": "collectible",
+          "text": "Collect **880 Gald** from the chest in the southwest crawl tunnel."
         },
         {
           "id": "step-081",
@@ -513,13 +975,36 @@
         {
           "id": "step-082",
           "type": "step",
-          "text": "Return to Loegres after completing the catacombs."
+          "text": "Return to Loegres after completing the catacombs. Restock and save."
         }
       ]
     },
     {
       "id": "loegres-villa",
       "title": "Loegres Villa",
+      "content": "## Loegres Villa — Infiltrating the Abbey’s Stronghold\n\nThe **Loegres Villa** is an Abbey-controlled mansion that your party must infiltrate as part of the main story. This section features tense stealth-adjacent exploration, multiple combat encounters with guards, missable equipment in side rooms, and culminates in significant boss fights.\n\n### Entering the Villa\n\nAfter the Barona Catacombs, the story directs you to infiltrate the Villa. Watch the introductory cutscene that establishes the stakes — key Abbey members are meeting here, and your party needs information.\n\n<!-- checkpoint: villa-entrance | Entered Loegres Villa -->\n\n### Villa Exploration\n\nNavigate counterclockwise through the villa, checking every room:\n\n**Ground Floor:**\n- **Panacea Bottle** — First side room on the left\n- **Rosemary** — Herb in the dining hall area\n- **Wind Ring** — Chest in a storage closet\n\n**Upper Floor:**\n- **Saffron** — Herb on the upper corridor\n- Additional equipment in bedrooms\n\n<!-- checkpoint: villa-items | Collected villa items -->\n\n### Important Warning\n\n**Search ALL rooms before progressing through the main hall door.** Several rooms contain missable equipment and items that become inaccessible after triggering the story confrontation. The villa does not allow backtracking after certain story triggers.\n\n### Story Confrontation\n\nReaching the main hall triggers the story confrontation. Cutscenes reveal important plot information about the Abbey’s plans and Artorius’s true objectives. After the dialogue, combat begins.\n\n<!-- checkpoint: villa-confrontation | Triggered the main hall confrontation -->\n\n### Boss: Eleanor (2nd Battle)\n\nBefore reaching Oscar, you fight **Eleanor Hume** again:\n\n- **HP:** 16,139\n- **Weakness:** Water\n- **Strategy:**\n  - She has backup support — defeat her allies first\n  - Use water-elemental attacks once she’s isolated\n  - At 50% HP, **Magilou joins** with a Switch Blast tutorial\n  - Use Switch Blast when prompted for massive damage\n  - After learning Switch Blast, finish Eleanor aggressively\n\n### Boss: Oscar Dragonia\n\nThe main boss of this section is **Oscar Dragonia** — a high-ranking exorcist.\n\n- **Weakness:** Susceptible to status ailments\n- **Strategy:**\n  - Use attacks and Mystic Artes that inflict ailments\n  - Guard against his powerful Arte combos — damage spikes are sudden\n  - Use Laphicet for consistent healing support\n  - Break Soul when Oscar staggers for extended combo windows\n  - Keep Life Bottles ready — his burst damage can KO unexpectedly\n\n<!-- checkpoint: villa-oscar | Defeated Oscar Dragonia -->\n\n### Post-Battle\n\nAfter defeating Oscar:\n1. Watch the important post-battle cutscenes\n2. The party regroups and discusses next steps\n3. Return to the tavern area to heal and save\n4. Open a **Katz Box** in the villa basement before leaving\n\n<!-- checkpoint: villa-complete | Completed Loegres Villa -->\n\nThis concludes the first major arc of Tales of Berseria. The story continues with new destinations and escalating conflicts against the Abbey.",
+      "checkpoints": [
+        {
+          "id": "villa-entrance",
+          "label": "Entered Loegres Villa"
+        },
+        {
+          "id": "villa-items",
+          "label": "Collected villa items"
+        },
+        {
+          "id": "villa-confrontation",
+          "label": "Triggered the main hall confrontation"
+        },
+        {
+          "id": "villa-oscar",
+          "label": "Defeated Oscar Dragonia"
+        },
+        {
+          "id": "villa-complete",
+          "label": "Completed Loegres Villa"
+        }
+      ],
       "steps": [
         {
           "id": "step-083",
@@ -529,12 +1014,17 @@
         {
           "id": "step-084",
           "type": "step",
-          "text": "Navigate through the villa corridors, defeating guards along the way."
+          "text": "Navigate through the villa corridors counterclockwise, defeating guards along the way."
         },
         {
           "id": "step-085",
           "type": "warning",
-          "text": "Search all rooms before progressing — several contain missable equipment and items."
+          "text": "Search all rooms before progressing — several contain missable equipment and items. No backtracking after story triggers."
+        },
+        {
+          "id": "step-085b",
+          "type": "collectible",
+          "text": "Collect **Panacea Bottle**, **Rosemary**, **Wind Ring**, and **Saffron** from villa rooms."
         },
         {
           "id": "step-086",
@@ -542,15 +1032,26 @@
           "text": "Reach the main hall and trigger the story confrontation."
         },
         {
+          "id": "step-086b",
+          "type": "boss",
+          "text": "**BOSS: Eleanor** — HP: 16,139. Weak to Water.",
+          "note": "Defeat allies first, then use water Artes. Magilou joins at 50% HP with Switch Blast tutorial."
+        },
+        {
           "id": "step-087",
           "type": "boss",
-          "text": "**BOSS: Oscar Dragonia** — Prepare for a tough fight with an exorcist-class enemy.",
-          "note": "Use Laphicet for healing support. Break Soul when Oscar staggers."
+          "text": "**BOSS: Oscar Dragonia** — Exorcist-class enemy vulnerable to status ailments.",
+          "note": "Use Laphicet for healing. Break Soul when Oscar staggers. Watch for burst damage spikes."
+        },
+        {
+          "id": "step-087b",
+          "type": "collectible",
+          "text": "Open the **Katz Box** in the villa basement before leaving."
         },
         {
           "id": "step-088",
           "type": "step",
-          "text": "Watch the post-battle cutscenes and regroup with the party."
+          "text": "Watch the post-battle cutscenes and regroup with the party at the tavern."
         }
       ]
     }

--- a/walkthroughs/the-legend-of-heroes-trails-of-cold-steel-ii/main-walkthrough.json
+++ b/walkthroughs/the-legend-of-heroes-trails-of-cold-steel-ii/main-walkthrough.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "$schema": "../walkthrough.schema.json",
   "id": "the-legend-of-heroes-trails-of-cold-steel-ii-main",
   "game": "The Legend of Heroes: Trails of Cold Steel II",
@@ -11,6 +11,12 @@
     {
       "id": "prologue-part-a",
       "title": "Prologue Part A: Eisengard Mountain Range (November 29)",
+      "content": "## Prologue Part A: Eisengard Mountain Range\n\nThe game opens one month after the devastating events that concluded Trails of Cold Steel. Rean Schwarzer awakens alone in the frozen Eisengard Mountain Range with no memory of how he arrived. The snowy peaks stretch endlessly, and the only path leads downhill through a narrow canyon filled with monsters.\n\n### Game Start & New Game Bonuses\n\nBegin a new game and select your preferred difficulty setting. If you possess clear save data from the first Trails of Cold Steel, you can import it for substantial bonuses including extra Sepith, bonus items, additional S-Craft attacks, and stat boosts depending on Rean's final level and academic rank from the previous game. Platinum trophy hunters should note that at least two full playthroughs are required.\n\nThe introduction sequence provides a dramatic recap of the climax of the first game — the Noble Alliance's coup d'état, the awakening of the Vermillion Apocalypse, and Rean's desperate activation of Valimar the Ashen Knight. Be warned that this contains major spoilers for the first game's ending.\n\n<!-- checkpoint: prologue-a-start | Gained control of Rean -->\n\n### First Steps in Eisengard\n\nAfter gaining control of Rean, the game introduces the **Save System** and **Navigation Menu** (press Square/touchpad to see your current objective). Head downhill along the snowy path. You'll spot a glowing object on the ground — examine it to recover Rean's tachi sword and basic equipment.\n\nOpen the main menu and navigate to the **Orbment** screen. Equip your **Master Quartz** (likely Force or Domination depending on your import). The Master Quartz system provides passive bonuses and levels up as you gain AP in battle, unlocking new Arts at higher levels.\n\n### Combat Tutorial & Monster Notes\n\nContinue downhill until you encounter your first monster — a **Helm Scorpion**. The game teaches you the pre-emptive strike system: approach enemies from behind or stun them with a field attack (Circle button) to gain advantages in battle including bonus turns, reduced enemy HP, and favorable positioning.\n\nAfter your first victory, the **Monster Notes** system is introduced. Every unique enemy you defeat or analyze fills out your bestiary, which contributes to your overall completion rating. Make it a habit to analyze every new enemy type you encounter.\n\n<!-- checkpoint: prologue-a-combat | Completed first battle -->\n\n### Eisengard Mountain Path\n\nProceed through **Eisengard Range - Map 2**. Shortly after entering, you'll find your first treasure chest containing a **Tear Quartz** (heals HP in battle). Continue east, fighting groups of Helm Scorpions, Rolling Stones (boulder-type enemies weak to Wind arts), and Sky Gazers (flying enemies weak to Time arts).\n\nExplore any branching paths for additional treasure chests containing Sepith and healing items. The monsters here provide good early experience and help you refamiliarize yourself with the combat system's mechanics including turn bonuses, S-Craft timing, and the AT (Action Time) bar.\n\n<!-- checkpoint: prologue-a-boss | Reached Magic Knight Ortheim -->\n\n### Boss: Magic Knight Ortheim\n\nAt the end of the canyon, you'll encounter the imposing **Magic Knight Ortheim** — a massive arcane construct blocking your path. This is a scripted encounter designed to introduce boss mechanics.\n\n**Strategy:** Simply attack the Magic Knight and deal as much damage as possible. The fight ends automatically once its HP drops to approximately 50% (around 10,000 HP). Use Rean's crafts — **Arc Slash** for reliable damage and **Motivate** if you need healing. Don't worry about running out of resources; the scene triggers regardless of your performance.\n\nAfter dealing sufficient damage, a dramatic cutscene plays where **Toval Randonneur** (a Bracer from the first game), **Princess Alfin**, and **Elise Schwarzer** arrive to rescue Rean. The group defeats Ortheim together and makes their escape from the mountains, eventually arriving at the village of Ymir.",
+      "checkpoints": [
+        { "id": "prologue-a-start", "label": "Gained control of Rean" },
+        { "id": "prologue-a-combat", "label": "Completed first battle" },
+        { "id": "prologue-a-boss", "label": "Reached Magic Knight Ortheim" }
+      ],
       "steps": [
         {
           "id": "pro-a-001",
@@ -47,19 +53,31 @@
         {
           "id": "pro-a-007",
           "type": "step",
-          "text": "Proceed down the canyon, fighting a few more enemies along the way."
+          "text": "Proceed down the canyon, fighting enemies including Helm Scorpions, Rolling Stones, and Sky Gazers. Check side paths for treasure chests."
         },
         {
           "id": "pro-a-008",
+          "type": "collectible",
+          "text": "Treasure chest in Eisengard Range Map 2 contains a **Tear Quartz**.",
+          "note": "Found shortly after entering the second map area."
+        },
+        {
+          "id": "pro-a-009",
           "type": "boss",
-          "text": "**BOSS: Magic Knight Ortheim** — Keep attacking until its HP drops to a trigger point, ending the fight automatically.",
-          "note": "This is a scripted battle; just keep dealing damage until the scene triggers."
+          "text": "**BOSS: Magic Knight Ortheim** — Keep attacking until its HP drops to approximately 50% (~10,000 HP), ending the fight automatically.",
+          "note": "This is a scripted battle; just keep dealing damage until the scene triggers. Use Arc Slash and Motivate as needed."
         }
       ]
     },
     {
       "id": "prologue-part-b",
       "title": "Prologue Part B: Ymir Village & Canyon (November 30)",
+      "content": "## Prologue Part B: Ymir Village & Canyon\n\nAfter the harrowing escape from Eisengard, Rean and his companions arrive in **Ymir** — the picturesque hot spring village nestled in the mountains of northern Erebonia that serves as Rean's hometown. One month has passed since the October War, and Erebonia remains in chaos with the Noble Alliance controlling most of the empire.\n\n### Exploring Ymir Village\n\nYmir is a small but cozy village with several important locations. **Red markers** on the mini-map indicate main story objectives, while **green markers** denote optional events and side content. Take time to explore thoroughly — this village serves as your home base for the early chapters.\n\n<!-- checkpoint: prologue-b-village | Arrived in Ymir Village -->\n\n**Key Locations:**\n- **Rean's Family Home** — Speak with Elise and Celine for character profile updates\n- **Ploval's General Store** — Purchase items and pick up the first collectible book\n- **Phoenix Wings Inn** — Rest and speak with NPCs for world-building dialogue\n- **Hot Springs** — Story-relevant location that unlocks later\n- **Ymir Chapel** — Small shrine area with NPC dialogue\n\n### Character Interactions & Collectibles\n\nSpeak with **Celine** (the talking cat, your divine beast companion) and **Elise** (Rean's adoptive sister) for their character profiles. Both have updated dialogue reflecting the current political situation in Erebonia.\n\nVisit **Ploval's General Store** to purchase supplies and, critically, to obtain **Gambler Jack Vol. 1** — the first entry in an ongoing book collection that spans the entire game. These books are often missable, so always check stores in every new area.\n\nTalk to every NPC you encounter, especially those with red exclamation marks overhead. Village residents provide context about the civil war, the Noble Alliance's activities, and rumors about your missing classmates from Class VII.\n\n<!-- checkpoint: prologue-b-canyon-start | Entered Ymir Canyon -->\n\n### Ymir Canyon Exploration\n\nWhen ready, proceed north out of Ymir Village to enter **Ymir Canyon** — a winding natural passage through the mountains. The canyon features moderate-difficulty enemies including wolf-type monsters and flying Zazas.\n\n**Tips for Canyon Navigation:**\n- Fight every enemy group for experience and Monster Note completion\n- Open all treasure chests — they contain Sepith, healing items, and equipment\n- Practice Link Attacks with your party members to build Link EXP\n- Use the Orbment system for healing between battles if needed\n\nThe canyon is relatively linear but has a few side paths with bonus treasure. Enemies here provide good practice for the game's deeper combat mechanics including turn bonus manipulation and craft timing.\n\n<!-- checkpoint: prologue-b-canyon-complete | Completed Ymir Canyon -->\n\n### Canyon Boss & Story Progression\n\nAt the canyon's end, you'll face a **large wolf-type boss**. Use S-Crafts and Link Attacks for efficient damage. After the battle, story events trigger that set up the plot for Act 1 — Rean learns about the state of Erebonia, the scattered members of Class VII, and the urgent need to reunite his companions.\n\n**Important reminders before leaving this area:**\n- Check all treasure chests in the canyon\n- Speak to all villagers and check stores for books and items\n- Use the Orbment system for healing and combat support\n- Make sure all character profiles are updated",
+      "checkpoints": [
+        { "id": "prologue-b-village", "label": "Arrived in Ymir Village" },
+        { "id": "prologue-b-canyon-start", "label": "Entered Ymir Canyon" },
+        { "id": "prologue-b-canyon-complete", "label": "Completed Ymir Canyon" }
+      ],
       "steps": [
         {
           "id": "pro-b-001",
@@ -94,11 +112,17 @@
         },
         {
           "id": "pro-b-007",
+          "type": "boss",
+          "text": "**BOSS: Canyon Wolf Pack Leader** — Use S-Crafts and Link Attacks. Exploit elemental weaknesses for bonus damage.",
+          "note": "Not overly difficult but good practice for link mechanics."
+        },
+        {
+          "id": "pro-b-008",
           "type": "step",
           "text": "Complete the canyon section to trigger story events leading into Act 1."
         },
         {
-          "id": "pro-b-008",
+          "id": "pro-b-009",
           "type": "note",
           "text": "Remember to check treasure chests in all new areas, use the Orbment system for healing and combat support, and speak to all villagers and check stores for books and useful items."
         }
@@ -107,6 +131,12 @@
     {
       "id": "act-1-part-1",
       "title": "Act 1 - Part 1: Ymir",
+      "content": "## Act 1 - Part 1: Ymir\n\nWith the prologue complete, Act 1 begins properly in Ymir. The village now opens up with additional systems, shops, and optional activities. Your goal is to prepare for the journey to reunite with your scattered Class VII companions.\n\n### New Systems Unlocked\n\nSeveral important gameplay systems become available at the start of Act 1:\n\n<!-- checkpoint: a1p1-systems | Quick Travel and shops unlocked -->\n\n**Quick Travel** — Access the navigation menu to fast-travel between discovered locations within the current area. This saves considerable backtracking time.\n\n**Weapon Synthesis** — Visit the general store and speak with **Raio** (the shopkeeper on the right side). He introduces weapon upgrading and the ability to unlock new Orbment Slots using U-Materials. Upgrading weapons provides substantial stat boosts.\n\n**Item Trading** — Talk to **Camillia** to unlock the item trading function, similar to the pawn shop from the first game. On New Game+ (second playthrough), Camillia offers to trade Zemurian Ore Shards for 50 U-Materials — extremely valuable for upgrading.\n\n### NPC Interactions & Items\n\nExplore the expanded village thoroughly:\n\n- **Luke** (near the wrecked station) gives you **Tear Balms** — useful healing items for the early game\n- Check the **general store** for updated inventory including new quartz and accessories\n- Talk to returning NPCs for updated dialogue about the civil war situation\n\n<!-- checkpoint: a1p1-leaves | Collected both Leaves -->\n\n### Collectible: Red Leaves\n\nTwo **Red Leaves** are hidden in the Ymir Valley areas. These are collectibles that contribute to completion:\n\n1. **First Leaf** — Located in the **northwest corner of Ymir Valley 1**. Look for a sparkling spot off the main path.\n2. **Second Leaf** — Found in the **upper southeast corner of Ymir Valley 2**, near a treasure chest. The chest itself contains useful equipment.\n\n<!-- checkpoint: a1p1-departure | Ready to depart Ymir -->\n\n### Preparing for Departure\n\nOnce you've completed all available activities in Ymir, it's time to head out. Make sure you have:\n- Equipped the best available gear and quartz\n- Purchased healing items from the store\n- Saved your game\n\nLeave via **Ymir Canyon** heading toward **Lunaria Nature Park** to progress the story.",
+      "checkpoints": [
+        { "id": "a1p1-systems", "label": "Quick Travel and shops unlocked" },
+        { "id": "a1p1-leaves", "label": "Collected both Leaves" },
+        { "id": "a1p1-departure", "label": "Ready to depart Ymir" }
+      ],
       "steps": [
         {
           "id": "a1p1-001",
@@ -149,6 +179,13 @@
     {
       "id": "act-1-part-2",
       "title": "Act 1 - Part 2: Nord Highlands (December 5)",
+      "content": "## Act 1 - Part 2: Nord Highlands\n\nOn December 5th, Rean and his companions travel through a Spirit Path to the vast **Nord Highlands** — the nomadic grasslands from the first game. Your mission: locate and recruit the scattered members of Class VII, starting with Gaius Worzel.\n\n### Party Formation\n\nBefore departing Ymir, you'll select your party:\n- Choose **two Class VII members** from those available (Elliot, Machias, Fie)\n- Select one **guest character**: either **Claire Rieveldt** or **Toval Randonneur**\n\n<!-- checkpoint: a1p2-arrive-nord | Arrived in Nord Highlands -->\n\n**Guest choice matters:** Your guest's Link Level contributes to an accessory reward later. Toval provides a casting speed accessory, while Claire grants an accuracy/critical accessory. Choose based on your preferred playstyle.\n\n### Nord Highlands — South\n\nThe southern plains of Nord are expansive. Use your map frequently to track treasure chests and points of interest.\n\n**Enemies in this area:**\n- Winged Snakes (weak to Wind)\n- Grass Hoppers (weak to Fire)\n- Brutal Infants (weak to Earth)\n- Ostriches (fast, watch for ambushes)\n- Brutal Buffa (high HP, use crafts)\n- Thunder Loach/Thunder Quaker (weak to Earth, can inflict Seal)\n\n**Treasure Chests (South Highlands):**\n- Curia Balm, Marble Ring, EP Charge II, Ingenuity Quartz, Teara Balm, Cloud Shoes, Sepith Mass x200\n\n<!-- checkpoint: a1p2-zender-gate | Reached Zender Gate -->\n\n### Zender Gate\n\nProceed southwest to reach **Zender Gate** — the military fortress that controls access between the highlands and the border. After a story scene, you receive a **horse** that dramatically speeds up overworld traversal.\n\n**At Zender Gate:**\n- Speak to **Marx** at the Mess Hall for the **Potato Croquette recipe** (missable!)\n- Check the weapon shop for upgraded equipment (skip armor — better pieces found at Lake Lacrima)\n- Find classmate **Beryl** in the Mess Hall and **Mint** outside the gate\n- Stock up on healing items for the upcoming boss fight\n\n### Journey to Nord Settlement\n\nLeave Zender Gate heading northeast toward the **Nord Settlement**. Along the way, you'll be ambushed by enemy forces.\n\n<!-- checkpoint: a1p2-jaeger-battle | Defeated the Jaegers -->\n\n### Boss: Jaeger Ambush\n\n**Enemies:** Jaeger - Greatsword (~11,229 HP) and Jaeger - Rifle (~10,488 HP)\n\nThese Jaegers hit extremely hard (2,000–3,500 damage per attack) and can revive fallen allies. This is a significant difficulty spike from the prologue.\n\n**Strategy:**\n- Focus fire on one Jaeger at a time to prevent revives\n- Use buffs immediately (Claire's Brave Order or Toval's support)\n- Deploy S-Crafts aggressively — don't save them\n- Keep the party healed above 60% HP at all times\n- The Rifle Jaeger is slightly less durable — consider targeting it first\n\n**Drops:** Curia Balm, Reviving Balm, Teara Balm, EP Charge II\n\nAfter victory, **Gaius** joins your party permanently.\n\n<!-- checkpoint: a1p2-side-quests | Side quests available -->\n\n### Side Quests & Optional Content\n\nWith Gaius recruited, several side quests become available. Complete them all for maximum AP:\n\n**Highlands Hunt** — A straightforward monster elimination quest in the highlands. Track down and defeat the target monsters.\n\n**Foaling Around** — Help find a missing horse near the settlement. Start near the sheep, track the horse northwest, and chase it until it returns to the Settlement.\n\n**Hidden Quest: Zats Amore** — Found by speaking to the weapon shop owner in Zender Gate specifically. Easy to miss if you don't revisit the shop after Gaius joins.\n\n**Hidden Quest: Azuki's Adventure** — Located at the goods store back in Ymir. You must return to Ymir to find this quest, so don't forget!\n\n### Optional: Aria Shrine\n\nIn **Nord Highlands – East**, there's an optional dungeon called the **Aria Shrine**. This contains a powerful boss (recommended for higher-level parties) and awards bonus AP upon completion. The shrine boss drops rare materials useful for weapon synthesis.",
+      "checkpoints": [
+        { "id": "a1p2-arrive-nord", "label": "Arrived in Nord Highlands" },
+        { "id": "a1p2-zender-gate", "label": "Reached Zender Gate" },
+        { "id": "a1p2-jaeger-battle", "label": "Defeated the Jaegers" },
+        { "id": "a1p2-side-quests", "label": "Side quests available" }
+      ],
       "steps": [
         {
           "id": "a1p2-001",
@@ -158,12 +195,14 @@
         {
           "id": "a1p2-002",
           "type": "step",
-          "text": "Select two Class VII members and a guest (**Claire** or **Toval**) for your party."
+          "text": "Select two Class VII members and a guest (**Claire** or **Toval**) for your party.",
+          "note": "Guest Link Level affects a later accessory reward. Toval gives casting speed; Claire gives accuracy/critical."
         },
         {
           "id": "a1p2-003",
           "type": "step",
-          "text": "Traverse **Nord Highlands - South**, using the map to collect all treasure chests."
+          "text": "Traverse **Nord Highlands - South**, using the map to collect all treasure chests.",
+          "note": "Chests contain: Curia Balm, Marble Ring, EP Charge II, Ingenuity, Teara, Cloud Shoes, Sepith Mass x200."
         },
         {
           "id": "a1p2-004",
@@ -174,7 +213,7 @@
           "id": "a1p2-005",
           "type": "collectible",
           "text": "Speak to **Marx** at the Mess Hall inside Zender Gate for the **Potato Croquette** recipe.",
-          "note": "Also check for new weapons here."
+          "note": "Also check for new weapons here. Skip armor — better pieces at Lake Lacrima."
         },
         {
           "id": "a1p2-006",
@@ -189,13 +228,13 @@
         {
           "id": "a1p2-008",
           "type": "boss",
-          "text": "**BOSS: Jaegers** — These enemies can revive allies and hit hard. Use buffs and S-Crafts.",
-          "note": "Focus fire on one Jaeger at a time to prevent revives."
+          "text": "**BOSS: Jaegers** — Jaeger-Greatsword (~11,229 HP) and Jaeger-Rifle (~10,488 HP). Focus fire on one at a time to prevent revives. Use S-Crafts aggressively.",
+          "note": "These enemies hit for 2,000-3,500 damage. Keep HP above 60% at all times. Gaius joins after victory."
         },
         {
           "id": "a1p2-009",
           "type": "step",
-          "text": "Complete side quest: **Highlands Hunt** — Simple kill quest in the Highlands."
+          "text": "Complete side quest: **Highlands Hunt** — Monster elimination quest in the Highlands."
         },
         {
           "id": "a1p2-010",
@@ -206,12 +245,13 @@
           "id": "a1p2-011",
           "type": "collectible",
           "text": "Hidden quest: **Zats Amore** — Found in Zender Gate's weapon shop.",
-          "note": "Easy to miss — speak to the shop owner specifically."
+          "note": "Easy to miss — speak to the shop owner specifically after Gaius joins."
         },
         {
           "id": "a1p2-012",
           "type": "step",
-          "text": "Explore the optional dungeon: **Aria Shrine** in Nord Highlands – East for bonus AP."
+          "text": "Explore the optional dungeon: **Aria Shrine** in Nord Highlands – East for bonus AP.",
+          "note": "Contains a powerful boss and rare material drops."
         },
         {
           "id": "a1p2-013",
@@ -224,6 +264,12 @@
     {
       "id": "act-1-part-3",
       "title": "Act 1 - Part 3: Return to Ymir & Divine Knight Battle",
+      "content": "## Act 1 - Part 3: Return to Ymir & Divine Knight Battle\n\nWith Gaius and the other Class VII members regrouped, the party returns to Ymir for the climactic conclusion of Act 1. This section culminates in your first full Divine Knight battle — a mech-on-mech clash that introduces one of Cold Steel II's signature combat systems.\n\n### Returning to Ymir\n\nAfter completing all available content in the Nord Highlands, travel back to Ymir. New story scenes trigger automatically upon arrival, advancing the plot toward the inevitable confrontation.\n\n<!-- checkpoint: a1p3-return | Returned to Ymir -->\n\n### Final Preparations\n\nBefore triggering the Loa Erebonius battle, complete all remaining side content:\n\n- **Aria Shrine Boss** — If not already defeated, this optional boss grants bonus AP\n- **Horse Racing** — Try to win the race at Zender Gate for additional rewards\n- **Any remaining side quests** — Check the quest log for incomplete entries\n- **Equipment check** — Ensure all party members have optimal gear and quartz\n\nVisit the Ymir lodge and complete your preparations. **Save before the fight** — there's no going back after this point.\n\n<!-- checkpoint: a1p3-point-of-no-return | Point of no return (save here) -->\n\n### Divine Knight Battle: Loa Erebonius\n\nThe **Loa Erebonius** is a massive arcane construct — a corrupted Divine Knight that towers over the battlefield. You control **Valimar** (Rean's Ashen Knight) with support from chosen pilot allies (typically Alisa, Elliot, and Laura).\n\n**Divine Knight Combat Mechanics:**\n- **Targeting System** — You must target specific body parts (Head, Body, Arms). The glowing part indicates vulnerability.\n- **Break System** — Hitting the correct vulnerable part builds toward a \"Break\" state where you can unleash devastating Rush or Burst attacks.\n- **Support Commands** — Your pilot allies provide healing (Spirit command), buffs, and additional damage.\n- **Guard** — Essential for surviving the boss's powerful attacks. Guard when you see charge-up animations.\n\n<!-- checkpoint: a1p3-loa-defeated | Defeated Loa Erebonius -->\n\n**Strategy for Loa Erebonius (~116,000 HP):**\n\n1. **Opening Phase** — Use the Analyze function immediately to register Loa Erebonius in your Battle Notebook. Probe each body part with normal attacks to find the vulnerable area (look for 2-3 stars).\n\n2. **Attack Pattern Recognition:**\n   - If the boss raises an arm → Target that arm\n   - If it charges/rears back → Target the body\n   - If it telegraphs a special move → Guard immediately\n\n3. **Support Pilot Roles:**\n   - **Elliot** — Best for healing with the Spirit command. Use when Valimar's HP drops below 60%\n   - **Alisa** — Provides attack buffs and ranged support damage\n   - **Laura** — Maximum burst damage during Break states\n\n4. **Key Techniques:**\n   - Use \"Morning Moon\" (Valimar's counter craft) against telegraphed body attacks\n   - Save your EX Art for when Loa Erebonius enters Break state\n   - Watch for Unbalance chances — these allow Rush (multi-hit) or Burst (single massive hit) attacks\n   - Keep HP above 50% at all times; the boss has one-shot potential on lower difficulties\n\n5. **Final Phase** — Below 30% HP, Loa Erebonius becomes more aggressive. Use Spirit command liberally and finish with Valimar's S-Craft if available.\n\n### Post-Battle\n\nAfter defeating Loa Erebonius, dramatic cutscenes play revealing major plot developments. The story progresses to the **Intermission Chapter**, transitioning the narrative to a very different setting.",
+      "checkpoints": [
+        { "id": "a1p3-return", "label": "Returned to Ymir" },
+        { "id": "a1p3-point-of-no-return", "label": "Point of no return (save here)" },
+        { "id": "a1p3-loa-defeated", "label": "Defeated Loa Erebonius" }
+      ],
       "steps": [
         {
           "id": "a1p3-001",
@@ -253,8 +299,8 @@
         {
           "id": "a1p3-006",
           "type": "boss",
-          "text": "**BOSS: Loa Erebonius (Divine Knight Battle)** — Control Valimar with support from Alisa, Elliot, and Laura.",
-          "note": "Target the glowing body part (head, body, or arms). Use Elliot for healing, Alisa for buffs, Laura for damage. Heal frequently with the Spirit command."
+          "text": "**BOSS: Loa Erebonius (Divine Knight Battle, ~116,000 HP)** — Control Valimar with support from Alisa, Elliot, and Laura.",
+          "note": "Target the glowing body part (head, body, or arms). Use Elliot for healing, Alisa for buffs, Laura for damage. Guard when the boss telegraphs powerful attacks."
         },
         {
           "id": "a1p3-007",
@@ -271,6 +317,13 @@
     {
       "id": "intermission",
       "title": "Intermission Chapter",
+      "content": "## Intermission Chapter: Aboard the Pantagruel\n\nThe Intermission is a dramatic shift in perspective. Rean finds himself aboard the **Pantagruel** — the Noble Alliance's massive flying battleship. Captured and surrounded by enemies, this chapter is primarily exploration and story-focused, culminating in a daring escape sequence.\n\n### Exploring the Pantagruel\n\nYou control Rean alone initially. The ship has two main areas (South and North) connected by corridors. Visit every room marked with a **red exclamation mark** to trigger mandatory story scenes with the ship's notable occupants.\n\n<!-- checkpoint: int-exploration | Explored all rooms -->\n\n**South Area:**\n- **Southeast Room** — Meet **Scarlet**, the Noble Alliance's flame-wielding enforcer. She provides insight into the Alliance's motivations.\n- **Northeast Room** — Encounter **Vulcan**, a powerful brawler and one of the Alliance's heavy hitters.\n\n**Central Area:**\n- **Dining Table** — Speak with **Bleublanc** (the Phantom Thief). His theatrical manner hides genuine intelligence about the political situation.\n\n**North Area:**\n- **Southeast Room** — Find **Xeno & Leonidas**, the jaeger duo. They respect strength and offer combat-related dialogue.\n- **Northeast Room** — Meet **McBurn**, the Blazing Demon. He's arguably the most powerful fighter on the ship and speaks cryptically about otherworldly matters.\n- **Southwest Room** — Encounter **Duvalie** (the Swift). Proud and competitive, she serves as a key opponent later.\n- **Northwest Room** — Speak with **Altina Orion**, the mysterious puppet-like girl who monitors Rean on behalf of the Ironbloods.\n\n<!-- checkpoint: int-spirit-unification | Gained Spirit Unification -->\n\n### Key Story Events\n\n**Second Floor (North) — Guest Room:** Go upstairs and knock on the guest room door. A critical cutscene plays where Rean gains the **Spirit Unification** ability — this powerful technique temporarily boosts all stats dramatically and becomes essential for later boss fights.\n\n**Your Room (South Area, Southwest):** Return to Rean's assigned quarters. Examine the flower vase near the air ducts to discover an escape route.\n\n### The Escape\n\nCrawl through the air duct system to begin your escape from the Pantagruel. From here, combat resumes — prepare your equipment and quartz before engaging enemies.\n\n<!-- checkpoint: int-escape-start | Began escape sequence -->\n\n**First Combat: Alliance Forces Soldiers (HP: 9,600 each)**\n- Use Rean's **Autumn Leaf Cutter** to cancel enemy arts (interrupts their casting)\n- Princess Alfin joins with healing arts — use her for EP-efficient damage\n- These soldiers are not too dangerous individually but can overwhelm if you let them cast freely\n\n**Collectibles During Escape:**\n- **West Room** — Celestial Balm (full party HP recovery item)\n- **East Room** — Orange Cape (accessory with defensive bonuses)\n\nProgress through the corridors, defeating Alliance soldiers as you go. Use the **Orbment Charging Station** at the southern end to fully heal before the boss fight.\n\n<!-- checkpoint: int-boss-defeated | Defeated Duvalie and Bleublanc -->\n\n### Boss: Duvalie & Bleublanc\n\n**Duvalie (HP: 85,316)** — Fast physical attacker with devastating sword techniques. Uses \"Radiant Butterfly\" for AoE damage.\n\n**Bleublanc (HP: 96,640)** — Illusion specialist who can inflict Confuse and uses delayed arts. Less durable than Duvalie.\n\n**Victory Condition:** You only need to bring **ONE** boss below 50% HP to win the fight.\n\n**Strategy:**\n- Focus all damage on a single target (Duvalie is recommended — lower HP)\n- Open with an S-Craft for immediate massive damage\n- Use Analyze on both bosses for Battle Notebook completion before focusing damage\n- Guard when Bleublanc telegraphs his illusion arts\n- If Rean has Spirit Unification available, activate it for the burst damage phase",
+      "checkpoints": [
+        { "id": "int-exploration", "label": "Explored all rooms" },
+        { "id": "int-spirit-unification", "label": "Gained Spirit Unification" },
+        { "id": "int-escape-start", "label": "Began escape sequence" },
+        { "id": "int-boss-defeated", "label": "Defeated Duvalie and Bleublanc" }
+      ],
       "steps": [
         {
           "id": "int-001",
@@ -358,13 +411,19 @@
           "id": "int-017",
           "type": "boss",
           "text": "**BOSS: Duvalie (HP: 85,316) & Bleublanc (HP: 96,640)** — You only need to bring ONE boss below 50% HP to win.",
-          "note": "Use an S-Craft for heavy damage. Scan both bosses with Analyze for notebook completion."
+          "note": "Focus all damage on Duvalie (lower HP). Open with an S-Craft. Scan both bosses with Analyze for notebook completion."
         }
       ]
     },
     {
       "id": "act-2-part-1",
       "title": "Act 2 - Part 1: Celdic",
+      "content": "## Act 2 - Part 1: Celdic\n\nAct 2 begins aboard the **Courageous** — the Thors Military Academy's legendary airship, now serving as Class VII's mobile headquarters. Your objective is to liberate Erebonian cities from Noble Alliance control, starting with the market town of **Celdic**.\n\n### The Courageous\n\nBefore departing, take time to explore your new base of operations:\n\n<!-- checkpoint: a2p1-courageous | Boarded the Courageous -->\n\n- **Quest Terminal** — Check for available missions and track your AP progress\n- **Party Setup** — **Millium** is mandatory for this Act; choose your remaining slots carefully\n- **Orbment Station** — Adjust quartz loadouts for the upcoming battles\n- **Becky's Shop** — If you recruited Becky earlier, she acts as an item trader aboard ship\n\n**Important Crafting Tip:** Combine an **Attack 2** quartz and **Action 2** quartz with 20 U-Materials to create an **Ex-Orb** for Valimar. There are two difficult Divine Knight battles in Act 2, so this upgrade is highly recommended.\n\n### Arriving in Celdic\n\nTravel to **Celdic** from the airship's navigation console. The town has been under Noble Alliance occupation and the residents are struggling.\n\n<!-- checkpoint: a2p1-celdic-arrive | Arrived in Celdic -->\n\n**Key Activities in Town:**\n- Talk to **Becky** at Celdic House to have her join the Courageous crew (+2 AP bonus — easy to miss!)\n- Visit all shops for updated inventory (weapons, armor, accessories, and quartz)\n- Speak with every NPC for character notebook updates and world-building\n- Check for new fishing spots and recipe ingredients\n\n### Side Quests\n\nAccept and clear all available quests before advancing the main story. Some quests have time limits and will lock out upon progression:\n\n- Check the quest board at the guild for posted missions\n- Speak to NPCs with green markers for hidden quests\n- Look for **Red Moon Rose** and **Imperial Chronicle** volumes in stores and bookshelves\n\n<!-- checkpoint: a2p1-boss | Completed Celdic liberation -->\n\n### Boss: Celdic Region Battle\n\nThe liberation of Celdic culminates in a significant boss encounter.\n\n**Strategy:**\n- Use Analyze or Battle Scope to check elemental weaknesses\n- Apply buffs before engaging (Attack Up, Defense Up, Speed Up)\n- Use crafts and arts strategically — don't blow all CP on the first turn\n- Keep characters healthy; the boss can spike damage unexpectedly\n- Millium's defensive crafts provide excellent party protection",
+      "checkpoints": [
+        { "id": "a2p1-courageous", "label": "Boarded the Courageous" },
+        { "id": "a2p1-celdic-arrive", "label": "Arrived in Celdic" },
+        { "id": "a2p1-boss", "label": "Completed Celdic liberation" }
+      ],
       "steps": [
         {
           "id": "a2p1-001",
@@ -407,13 +466,19 @@
           "id": "a2p1-008",
           "type": "boss",
           "text": "**BOSS: Celdic Region Boss** — Check elemental weaknesses with Analyze or Battle Scope. Use crafts and arts strategically.",
-          "note": "Keep characters healthy and prepare buffs before engaging."
+          "note": "Keep characters healthy and prepare buffs before engaging. Millium's defensive crafts help greatly."
         }
       ]
     },
     {
       "id": "act-2-part-2",
       "title": "Act 2 - Part 2: Roer",
+      "content": "## Act 2 - Part 2: Roer\n\nThe industrial city of **Roer** — home to the Reinford Group and Alisa's family — is next on your liberation campaign. This section features both ground combat and a pivotal Divine Knight battle.\n\n### Courageous Preparations\n\nBefore traveling to Roer, take care of business aboard the Courageous:\n\n<!-- checkpoint: a2p2-prep | Completed Courageous preparations -->\n\n- Speak to **Celine** on 3F to update her profile\n- Talk to **Princess Alfin** to receive the **Medal of Charity** (valuable accessory)\n- Play **Blade** card games with allies to raise Link EXP — this directly affects combat teamwork effectiveness\n- Check shops for any new inventory\n\n### Roer City\n\nTravel to Roer via the airship navigation. The city is a sprawling industrial complex with multiple districts.\n\n<!-- checkpoint: a2p2-roer-arrive | Arrived in Roer -->\n\n**Main Story Progression:**\n- Follow the story markers through Roer's districts\n- Visit the Bracer Guild for progression events\n- Explore the R&D Lab and Factory areas as the story directs\n- Engage in available side quests throughout\n\n**Important Side Content:**\n\n**Schwarzdrache Fortress** — Travel via Nortia Highway to visit this fortress for an optional event worth +2 AP. This MUST be done before proceeding to Sachsen Iron Mine.\n\n**Creeping for Creeps** — Side quest available at Phoenix Wings in Ymir. Requires a mini-boss fight for maximum AP reward.\n\n<!-- checkpoint: a2p2-divine-knight | Completed Divine Knight battle -->\n\n### Divine Knight Battle (Valimar)\n\nThe Roer section culminates in a challenging Divine Knight battle. This is significantly harder than the Loa Erebonius fight from Act 1.\n\n**Preparation:**\n- Ensure Valimar's Ex-Orb is equipped (crafted earlier from Attack 2 + Action 2 + 20 U-Materials)\n- Optimize Valimar's orbment loadout for both offense and survivability\n\n**Strategy:**\n- Exploit elemental weaknesses when targeting body parts\n- Break the opponent's guard for critical damage windows\n- Use S-Crafts and Overdrive at critical moments for burst damage\n- Guard proactively when the enemy telegraphs heavy attacks\n- Heal with Spirit command whenever HP drops below 50%\n- Save EX Arts for Break state opportunities",
+      "checkpoints": [
+        { "id": "a2p2-prep", "label": "Completed Courageous preparations" },
+        { "id": "a2p2-roer-arrive", "label": "Arrived in Roer" },
+        { "id": "a2p2-divine-knight", "label": "Completed Divine Knight battle" }
+      ],
       "steps": [
         {
           "id": "a2p2-001",
@@ -454,13 +519,21 @@
         {
           "id": "a2p2-008",
           "type": "boss",
-          "text": "**BOSS: Divine Knight Battle (Valimar)** — Optimize orbments before this fight. Exploit elemental weaknesses, break guards, and use S-Crafts and Overdrive at critical moments."
+          "text": "**BOSS: Divine Knight Battle (Valimar)** — Optimize orbments before this fight. Exploit elemental weaknesses, break guards, and use S-Crafts and Overdrive at critical moments.",
+          "note": "Significantly harder than Act 1's mech battle. Ensure Ex-Orb is equipped."
         }
       ]
     },
     {
       "id": "act-2-part-3",
       "title": "Act 2 - Part 3: Legram & Bareahard (December 23)",
+      "content": "## Act 2 - Part 3: Legram & Bareahard\n\nOn December 23rd, the liberation campaign continues to the lakeside town of **Legram** (Laura's hometown) and the noble city of **Bareahard** (Jusis's territory). This section is rich with character development and multiple side quests.\n\n### Courageous Activities (December 23)\n\nAfter regaining control aboard the Courageous:\n\n<!-- checkpoint: a2p3-courageous | Completed December 23 preparations -->\n\n- Speak to **Towa** twice at the bridge for story updates and quest coordination\n- Visit the 4th floor training facility — talk to **Emily** and **Alan** to update their profiles\n- Interact with **Dorothee** on the 2nd floor to receive the **Pasta recipe** (cooking collectible)\n- Play **Blade** card games with allies for more Link EXP bonuses\n\n### Legram — Laura's Hometown\n\nLegram is a quaint lakeside town known for its swordsmanship tradition and the legendary Arseid family.\n\n<!-- checkpoint: a2p3-legram | Completed Legram quests -->\n\n**Side Quests in Legram:**\n\n1. **The Sweetest of Challenges** — A baking/cooking challenge quest that tests your recipe knowledge\n2. **Gone Air** — Investigation quest involving a missing airship or delivery. Follow NPC leads through town.\n3. **Kreuzen for a Bruisin'** — Combat-oriented quest likely involving monster hunting in the surrounding area\n\nComplete all three before advancing the main story for maximum AP.\n\n### Bareahard — The Duke's Territory\n\nAfter completing **The Duke's Arrest** story event, the **Bareahard Stopover** quest starts automatically, taking you to Jusis's home city.\n\n<!-- checkpoint: a2p3-bareahard | Visited Bareahard -->\n\n**Key Events:**\n- Visit the **Albarea Mansion** and enter the Annex for a pivotal scene with Jusis\n- Explore Bareahard's shops and speak with NPCs for updated dialogue\n- Check stores for books, recipes, and equipment upgrades\n\nAfterward, head to the **Bareahard Airport** and return to the Courageous to advance.\n\n### Optional Challenges\n\n**Cryptid Hunts:** Two powerful optional monsters can be challenged:\n- **Nortia Highway 2** — Cryptid boss with high rewards\n- **Eisengard Mountain 2** — Another cryptid encounter\n\nThese are tough fights but provide excellent gear and AP bonuses.\n\n<!-- checkpoint: a2p3-spirit-shrine | Completed Spirit Shrine trial -->\n\n### Spirit Shrine Trial\n\nAs part of the story progression, you'll enter a Spirit Shrine. Bring **Emma** for these trials as she's required for plot purposes.\n\n**Boss: Spirit Shrine Trial** — Battle against a Magic Knight or empowered guardian within the shrine. These fights test your mastery of elemental weaknesses and party coordination.",
+      "checkpoints": [
+        { "id": "a2p3-courageous", "label": "Completed December 23 preparations" },
+        { "id": "a2p3-legram", "label": "Completed Legram quests" },
+        { "id": "a2p3-bareahard", "label": "Visited Bareahard" },
+        { "id": "a2p3-spirit-shrine", "label": "Completed Spirit Shrine trial" }
+      ],
       "steps": [
         {
           "id": "a2p3-001",
@@ -516,18 +589,26 @@
           "id": "a2p3-011",
           "type": "step",
           "text": "Challenge the two cryptids at **Nortia Highway 2** and **Eisengard Mountain 2**.",
-          "note": "Optional but gives good rewards."
+          "note": "Optional but gives good rewards and bonus AP."
         },
         {
           "id": "a2p3-012",
           "type": "boss",
-          "text": "**BOSS: Spirit Shrine Trial** — Battle against a Magic Knight or cryptid. Bring Emma for shrine trials (required for plot)."
+          "text": "**BOSS: Spirit Shrine Trial** — Battle against a Magic Knight or cryptid. Bring Emma for shrine trials (required for plot).",
+          "note": "Use elemental weaknesses and keep party coordination tight."
         }
       ]
     },
     {
       "id": "act-2-part-4",
       "title": "Act 2 - Part 4: Spirit Shrines & Preparation",
+      "content": "## Act 2 - Part 4: Spirit Shrines & Final Preparation\n\nThis section revolves around completing the remaining **Spirit Shrine** trials scattered across Erebonia. Each shrine tests your party with powerful Magic Knight bosses, and clearing them all is essential for awakening Valimar's full potential. Afterward, the story barrels toward the Finale.\n\n### Collectibles & Hidden Quests\n\nBefore entering the shrines, gather important collectibles:\n\n<!-- checkpoint: a2p4-collectibles | Gathered all collectibles -->\n\n**Books & Recipes:**\n- **Curry Recipe Book** and **Mixed Grill** — Purchase from Fortnum Books (Christie's Galleria 2F) in Bareahard\n- **Gambler Jack Reprint #13** and **Gambler Jack Reprint #14** — Found at **Arseid Mansion** in Legram\n\n**Hidden Quest: Father's Pocket Watch** — Start this quest at Jackass' Repair Shop in Roer. **Alisa must be in your party** to trigger it. This is a missable hidden quest that provides significant AP and character development for Alisa.\n\n### The Spirit Shrines\n\nEach Spirit Shrine is an elemental dungeon ending with a powerful Magic Knight boss. Bring a balanced party with healing, buffing, and elemental coverage.\n\n<!-- checkpoint: a2p4-shrine-1 | Cleared first Spirit Shrine -->\n\n**General Shrine Tips:**\n- Explore thoroughly — treasure chests contain rare quartz and gear\n- Each shrine has elemental theming; bring quartz and arts that exploit the opposing element\n- Equip anti-status accessories (Petrify, Freeze, Burn resistance depending on shrine)\n- Stock up on Zeram Powders and Celestial Balms before each shrine\n\n### Boss: Magic Knight Heavy Ruby\n\nThe first major shrine boss. A fire-aspected knight with powerful AoE attacks.\n\n**Strategy:**\n- Use Water-element arts for weakness exploitation\n- Equip Burn-resistance accessories\n- Emma's AoE healing is invaluable here\n- Watch for the charge-up animation — Guard or use delay crafts to interrupt\n\n### Boss: Magic Knight Isra-Zeriel\n\nA more defensive shrine boss with high HP and guard mechanics.\n\n**Strategy:**\n- Keep the party healed at all times — this fight is a war of attrition\n- Use Overdrive for burst healing and damage during critical phases\n- Break its guard with repeated strikes to the same body part\n- Don't overcommit CP — keep reserves for emergency healing\n\n<!-- checkpoint: a2p4-shrine-final | Cleared all Spirit Shrines -->\n\n### Boss: Grianos-Aura\n\nThe final and most powerful shrine boss. This fight occurs after a Vita memory scene and represents a significant power spike.\n\n**Strategy:**\n- This is the strongest shrine boss — prepare your absolute best gear and quartz\n- Full party buffs are mandatory (Attack, Defense, Speed)\n- Use S-Crafts during Break windows for maximum damage\n- Have at least two characters capable of emergency healing\n- Overdrive liberally — don't save it for later\n\n<!-- checkpoint: a2p4-point-of-no-return | Point of no return for Act 2 -->\n\n### Final Warning: Point of No Return\n\nAfter obtaining all crystals from the shrines, a forced event triggers leading to **Liberating Trista** — the operation to free Thors Military Academy. Complete ALL remaining side content NOW:\n\n- All hidden quests\n- All book and recipe collections for this Act\n- Any remaining Blade matches for Link EXP\n- Cryptid hunts and optional bosses\n\n### Act 2 Final Battles\n\nThe act ends with two consecutive party battles. Note that **Sara is unavailable** and two guest characters assist instead. Ensure your primary party is well-equipped with a focus on strong attackers: Rean, Laura, Gaius, and Millium are recommended for their high damage output and survivability.",
+      "checkpoints": [
+        { "id": "a2p4-collectibles", "label": "Gathered all collectibles" },
+        { "id": "a2p4-shrine-1", "label": "Cleared first Spirit Shrine" },
+        { "id": "a2p4-shrine-final", "label": "Cleared all Spirit Shrines" },
+        { "id": "a2p4-point-of-no-return", "label": "Point of no return for Act 2" }
+      ],
       "steps": [
         {
           "id": "a2p4-001",
@@ -544,28 +625,31 @@
           "id": "a2p4-003",
           "type": "collectible",
           "text": "Hidden Quest: **Father's Pocket Watch** — Start at Jackass' Repair Shop in Roer (Alisa must be in party).",
-          "note": "Missable hidden quest."
+          "note": "Missable hidden quest worth significant AP."
         },
         {
           "id": "a2p4-004",
           "type": "step",
-          "text": "Continue through **Spirit Shrine** quests. Each shrine trial culminates in a boss fight."
+          "text": "Continue through **Spirit Shrine** quests. Each shrine trial culminates in a boss fight.",
+          "note": "Bring anti-status accessories and stock up on Zeram Powders and Celestial Balms."
         },
         {
           "id": "a2p4-005",
           "type": "boss",
-          "text": "**BOSS: Magic Knight Heavy Ruby** — Spirit Shrine boss. Use Emma's arts and exploit weaknesses."
+          "text": "**BOSS: Magic Knight Heavy Ruby** — Spirit Shrine boss. Use Water-element arts and exploit weaknesses. Equip Burn resistance.",
+          "note": "Watch for charge-up animations — Guard or use delay crafts."
         },
         {
           "id": "a2p4-006",
           "type": "boss",
-          "text": "**BOSS: Magic Knight Isra-Zeriel** — Spirit Shrine boss. Keep party healed and use Overdrive."
+          "text": "**BOSS: Magic Knight Isra-Zeriel** — Spirit Shrine boss. Keep party healed and use Overdrive for burst phases.",
+          "note": "War of attrition fight. Don't overcommit CP."
         },
         {
           "id": "a2p4-007",
           "type": "boss",
           "text": "**BOSS: Grianos-Aura** — Final shrine boss, a powered-up version after Vita's memory scene.",
-          "note": "Strongest shrine boss. Prepare your best gear and quartz."
+          "note": "Strongest shrine boss. Full party buffs mandatory. Use S-Crafts during Break windows."
         },
         {
           "id": "a2p4-008",
@@ -582,6 +666,14 @@
     {
       "id": "finale",
       "title": "Finale: Infernal Castle & Trista Liberation",
+      "content": "## Finale: Infernal Castle & Trista Liberation\n\nThe Finale is the game's climactic dungeon — the **Infernal Castle**, a towering arcane fortress that has risen from the earth near Trista. This multi-stratum dungeon culminates in a gauntlet of boss battles against the game's most powerful antagonists, followed by the final confrontation.\n\n### Pre-Dungeon Preparation\n\n<!-- checkpoint: fin-preparation | Entered Infernal Castle -->\n\n**Essential Preparations:**\n- Stock up on Zeram Powders, Celestial Balms, EP Charge IVs, and Reviving Balms\n- Equip status-prevention accessories (Faint, Sleep, Freeze, Confuse resistance)\n- Set Master Quartz for either strong healing/support (Emma, Alisa) or maximum damage (Rean, Laura)\n- Configure multiple party loadouts — you'll need different teams for different strata\n- **Save in a separate slot** before entering\n\n### 1st Stratum\n\nThe first level of the Infernal Castle introduces the dungeon's mechanics:\n\n- Hit the **switch** near the sealed door to open it\n- Continue to the stairs; hit the switch at the end to create a bridge, then cross\n- Fight through corridor enemies — use Analyze on all new types\n\n**Party Tip:** Bring **Laura** in your party for a character profile note at the end of the 1st Stratum fight.\n\n### 2nd Stratum\n\nThe second level features eye-based puzzle mechanics:\n\n- Strike the \"eye\" symbols on walls to open passages forward\n- Navigate: continue north, then east/south following the eye patterns\n- More powerful enemies appear here including Nosferatu variants\n\n**Party Tip:** **Fie** must be in your party for the 2nd Stratum end fight (profile note).\n\n<!-- checkpoint: fin-3rd-stratum | Reached 3rd Stratum -->\n\n### 3rd Stratum\n\nThe most complex level with multiple paths and barrier puzzles:\n\n- Hit the switch near the sealed door\n- Defeat **Nosferatu** behind the door (powerful undead enemy)\n- **Navigation puzzle:** Take left, right, center, then center again to avoid triggering enemy barrier fights\n- Cross the external corridor and climb to the top\n\n### Boss Gauntlet\n\nAt the top of the castle, you face a grueling series of consecutive boss battles. Heal between fights when possible.\n\n<!-- checkpoint: fin-gauntlet-start | Started boss gauntlet -->\n\n**BOSS 1: Bleublanc, Duvalie & Balancing Clowns**\n- Focus on taking out the Clowns first (they buff the main bosses)\n- Duvalie uses fast physical AoE; Bleublanc uses Confuse and delay arts\n- Equip Confuse-resistance accessories\n\n**BOSS 2: Xeno & Leonidas**\n- Xeno is fast with critical hits and delay; Leonidas uses heavy physical attacks with self-buffs\n- Focus one target at a time — recommend taking Xeno first (more dangerous due to speed)\n- Use ATS/ADF debuffs on both\n\n**BOSS 3: McBurn (The Blazing Demon)**\n- Extremely powerful hybrid attacker (physical and magic). Inflicts Burn.\n- Below 50% HP, he enters \"Blazing\" mode with massively boosted stats\n- Use Water-element arts (his weakness)\n- Save S-Crafts for his powered-up phase\n- Buff defense constantly and keep HP topped off — he can one-shot careless parties\n\n<!-- checkpoint: fin-crow-battle | Reached Crow confrontation -->\n\n### Boss: Crow Armbrust (Ground Battle)\n\nThe emotional confrontation with your former classmate. Crow is agile with strong crafts.\n\n**Strategy:**\n- Crow uses **Arcadia's Gale** (devastating S-Craft) when his CP is full\n- Debuff his speed and attack stats\n- Keep party HP high at all times — his crafts hit multiple targets\n- Use defense/speed buffs and hit him with your own S-Crafts during openings\n- Consider using Spirit Unification for Rean's burst damage\n\n### Boss: Ordine (Divine Knight Battle — Valimar vs. Ordine)\n\nThe climactic mech duel between Rean's Valimar and Crow's Ordine.\n\n**Strategy:**\n- Target the glowing weak point (cycles between head, body, and arms)\n- Guard when Ordine telegraphs S-Craft moves (specific animation cue)\n- Use Spirit command for healing between exchanges\n- Unbalance Ordine for Rush/Burst follow-up attacks\n- Use EX Arts when Ordine is in Break state for maximum damage\n\n<!-- checkpoint: fin-vermillion | Vermillion Apocalypse battle -->\n\n### Boss: Vermillion Apocalypse (Phase 1)\n\nYour backline/reserve party handles this initial phase.\n\n**Strategy:**\n- Manage healing and buffs carefully with your secondary team\n- Focus on survival and consistent damage\n- Don't panic — this phase has a reasonable HP threshold\n\n### Boss: Vermillion Apocalypse (Phase 2)\n\nYour main party takes over for the true final battle of the Finale.\n\n**Strategy:**\n- Use your strongest S-Crafts and Overdrive combos\n- Buffs and debuffs are absolutely essential (Attack Up, Defense Down on boss)\n- Save Overdrive for critical healing or burst damage moments\n- The boss has wide AoE attacks — spread your party when possible\n- Keep at least one character alive at all times with emergency items\n\nAfter defeating the Vermillion Apocalypse, watch the emotional conclusion cutscenes. The main story concludes, but the game continues with additional content.",
+      "checkpoints": [
+        { "id": "fin-preparation", "label": "Entered Infernal Castle" },
+        { "id": "fin-3rd-stratum", "label": "Reached 3rd Stratum" },
+        { "id": "fin-gauntlet-start", "label": "Started boss gauntlet" },
+        { "id": "fin-crow-battle", "label": "Reached Crow confrontation" },
+        { "id": "fin-vermillion", "label": "Vermillion Apocalypse battle" }
+      ],
       "steps": [
         {
           "id": "fin-001",
@@ -641,41 +733,44 @@
         {
           "id": "fin-012",
           "type": "boss",
-          "text": "**BOSS: Bleublanc, Duvalie & Balancing Clowns** — First of the gauntlet battles at the top."
+          "text": "**BOSS: Bleublanc, Duvalie & Balancing Clowns** — Take out Clowns first (they buff bosses). Equip Confuse resistance.",
+          "note": "Duvalie uses fast physical AoE; Bleublanc uses Confuse and delay arts."
         },
         {
           "id": "fin-013",
           "type": "boss",
-          "text": "**BOSS: Xeno & Leonidas** — Second gauntlet battle. Focus one target at a time."
+          "text": "**BOSS: Xeno & Leonidas** — Focus one target at a time. Take Xeno first (more dangerous due to speed).",
+          "note": "Use ATS/ADF debuffs on both. Leonidas buffs himself — dispel when possible."
         },
         {
           "id": "fin-014",
           "type": "boss",
-          "text": "**BOSS: McBurn** — Extremely powerful. Use your best S-Crafts and keep HP topped off.",
-          "note": "McBurn hits incredibly hard. Buff defense and use Overdrive for burst healing."
+          "text": "**BOSS: McBurn** — Extremely powerful. Use Water-element arts (his weakness). Save S-Crafts for his Blazing mode below 50% HP.",
+          "note": "McBurn hits incredibly hard. Buff defense constantly and use Overdrive for burst healing."
         },
         {
           "id": "fin-015",
           "type": "boss",
-          "text": "**BOSS: Crow Armbrust (Ground Battle)** — Crow is agile with strong crafts and S-Craft \"Arcadia's Gale\". Keep HP high and use defense/speed buffs.",
-          "note": "Debuff Crow and hit him with your own S-Crafts when his guard is down."
+          "text": "**BOSS: Crow Armbrust (Ground Battle)** — Crow is agile with strong crafts and S-Craft \"Arcadia's Gale\". Debuff his speed/attack. Keep HP high.",
+          "note": "Use Spirit Unification for Rean's burst damage. Hit with S-Crafts when his guard is down."
         },
         {
           "id": "fin-016",
           "type": "boss",
           "text": "**BOSS: Ordine (Divine Knight Battle — Valimar vs. Ordine)** — Target the glowing weak point (head, body, or arms). Unbalance Ordine for follow-up attacks.",
-          "note": "Guard when Ordine telegraphs S-Craft moves. Use Spirit command for healing. Use EX Arts when Ordine is stunned."
+          "note": "Guard when Ordine telegraphs S-Craft moves. Use Spirit command for healing. Use EX Arts when Ordine is in Break state."
         },
         {
           "id": "fin-017",
           "type": "boss",
-          "text": "**BOSS: Vermillion Apocalypse (Phase 1)** — Backline/reserve party handles this phase. Manage healing and buffs carefully."
+          "text": "**BOSS: Vermillion Apocalypse (Phase 1)** — Backline/reserve party handles this phase. Focus on survival and consistent damage.",
+          "note": "Manage healing and buffs carefully with your secondary team."
         },
         {
           "id": "fin-018",
           "type": "boss",
-          "text": "**BOSS: Vermillion Apocalypse (Phase 2)** — Your main party takes over. Use strongest S-Crafts; buffs and debuffs are essential.",
-          "note": "Save Overdrive for critical healing or burst damage moments."
+          "text": "**BOSS: Vermillion Apocalypse (Phase 2)** — Your main party takes over. Use strongest S-Crafts and Overdrive combos.",
+          "note": "Save Overdrive for critical healing or burst damage. Buffs and debuffs are absolutely essential."
         },
         {
           "id": "fin-019",
@@ -687,6 +782,13 @@
     {
       "id": "divertissement",
       "title": "Divertissement: Crossbell (Lloyd & Rixia)",
+      "content": "## Divertissement: Crossbell\n\nAfter the Finale's conclusion, the game shifts perspective entirely to **Crossbell** — a different nation featured in the Trails from Zero/Azure games. You play as **Lloyd Bannings** (a detective) and **Rixia Mao** (a combat performer) as they infiltrate **Geofront E**, Crossbell's underground maintenance tunnels.\n\n### Important Limitations\n\n<!-- checkpoint: div-start | Started Divertissement -->\n\n- Only **two party members** are available for the entire chapter\n- **No shops** exist — you must rely on found items and crafted quartz\n- Leveling up and collecting quartz from enemies/chests is crucial for survival\n- Lloyd handles healing and support; Rixia provides speed and burst damage\n\n**Recommended Quartz to Equip/Farm:**\n- Defense 3, Hit 2, Water, Impede 1-2, Action 3, HP 2/3, Attack 3\n- Use Lloyd's S-Craft (**Raging Sun**) during Sepith-Up bonus turns for efficient farming\n\n### Geofront E — Starting Area\n\nBegin in the central hub of Geofront E:\n\n1. Head to the **north room** and examine the computer terminal to read the Crossbell Times (world-building context)\n2. Proceed **west** down the hallway\n3. Fight the **mini-boss** (slime group) at the door — they may drop useful quartz\n\n<!-- checkpoint: div-puzzle-area | Reached switch puzzles -->\n\n### Southwest Exploration & Switch Puzzles\n\n**Southwest corner:** Open the chest for a **Celestial Balm EX** (full heal for both characters — save this for the boss).\n\nReturn north and take the **east corridor** to its end. Enter the **air duct** system. Open the chest inside for an **EP Charge IV**.\n\nDescend the nearby stairs to reach the switch puzzle area. Two switches are present: one north, one south.\n\n**Secret:** Before flipping switches, go left of the north switch and climb down the ladder. You'll find a **monster chest** — defeat the guardian for a **Grail Locket** (excellent accessory for this chapter).\n\n### Switch Puzzle Solution\n\n1. Flip the **north switch** (moves a ladder into position)\n2. Flip the **south switch** (lowers a bridge)\n3. Head upstairs via the northwest ladder\n4. Move all the way south to the southeast area\n5. Descend the ladder and enter the west-side air duct\n6. Find **Seven Dragon Armor** in a chest (powerful equipment for Rixia)\n\n<!-- checkpoint: div-deeper | Progressing through Geofront -->\n\n### Deeper Geofront\n\nContinue using switches to lower bridges and reposition ladders as you progress deeper into the facility. The enemies grow stronger — keep both characters healed and don't hesitate to use items.\n\n**Combat Tips for Two-Character Party:**\n- Lloyd's crafts provide healing, buffs, and area control\n- Rixia's speed allows her to act first — use this for pre-emptive buffs or burst damage\n- Use S-Crafts on tough enemy groups rather than saving them exclusively for the boss\n- Link Attacks trigger frequently with only two characters — exploit this\n\n<!-- checkpoint: div-boss | Reached Central Computer Room -->\n\n### Boss: Central Computer Room Battle\n\nThe final encounter takes place in the Central Computer Room at Geofront E's deepest point.\n\n**Preparation:**\n- Heal to full HP and EP at the terminal before entering\n- Equip your best gear (Seven Dragon Armor on Rixia, defensive accessories on Lloyd)\n- Have items ready — Celestial Balm EX, EP Charges, and any Reviving Balms\n\n**Strategy:**\n- This is a tough fight with only two characters — resource management is critical\n- Lloyd handles healing and debuffs; Rixia handles damage\n- Use S-Crafts for burst damage during vulnerable windows\n- Don't hesitate to use all remaining items — there's nothing to save them for after this fight\n- If one character falls, revive immediately — you cannot sustain with just one fighter\n\nAfter victory, the Divertissement concludes and control returns to Rean's story for the Epilogue.",
+      "checkpoints": [
+        { "id": "div-start", "label": "Started Divertissement" },
+        { "id": "div-puzzle-area", "label": "Reached switch puzzles" },
+        { "id": "div-deeper", "label": "Progressing through Geofront" },
+        { "id": "div-boss", "label": "Reached Central Computer Room" }
+      ],
       "steps": [
         {
           "id": "div-001",
@@ -712,7 +814,8 @@
         {
           "id": "div-005",
           "type": "collectible",
-          "text": "Southwest corner: Open chest for **Celestial Balm EX**."
+          "text": "Southwest corner: Open chest for **Celestial Balm EX**.",
+          "note": "Save this for the final boss — it fully heals both characters."
         },
         {
           "id": "div-006",
@@ -732,7 +835,8 @@
         {
           "id": "div-009",
           "type": "collectible",
-          "text": "Go left of the north switch and climb down the ladder to a monster chest. Defeat the monster for a **Grail Locket**."
+          "text": "Go left of the north switch and climb down the ladder to a monster chest. Defeat the monster for a **Grail Locket**.",
+          "note": "Excellent accessory for this chapter — don't miss it."
         },
         {
           "id": "div-010",
@@ -747,7 +851,8 @@
         {
           "id": "div-012",
           "type": "collectible",
-          "text": "Descend the ladder and enter the west-side air duct. Find **Seven Dragon Armor** in a chest."
+          "text": "Descend the ladder and enter the west-side air duct. Find **Seven Dragon Armor** in a chest.",
+          "note": "Powerful equipment for Rixia — equip immediately."
         },
         {
           "id": "div-013",
@@ -763,13 +868,21 @@
           "id": "div-015",
           "type": "boss",
           "text": "**BOSS: Central Computer Room Battle** — Ensure Lloyd and Rixia are fully healed and equipped before engaging.",
-          "note": "This is a tough fight with only two characters. Use all available healing items and craft combos."
+          "note": "Tough fight with only two characters. Use all available healing items and craft combos. Don't save items — there's nothing after this."
         }
       ]
     },
     {
       "id": "epilogue",
       "title": "Epilogue: Reverie Corridor",
+      "content": "## Epilogue: Reverie Corridor\n\nThe **Reverie Corridor** is the game's post-story dungeon — a massive, multi-layered labyrinth accessed through the **Old Schoolhouse** at Thors Academy. It serves as the ultimate challenge and contains the true final boss of the game.\n\n### Corridor Overview\n\n<!-- checkpoint: epi-enter | Entered Reverie Corridor -->\n\nThe Reverie Corridor consists of **16 randomly-ordered floors** with four elemental themes:\n- **Earth floors** — Brown/rocky aesthetic, earth-aspected enemies\n- **Water floors** — Blue/aquatic aesthetic, water-aspected enemies\n- **Fire floors** — Red/volcanic aesthetic, fire-aspected enemies\n- **Wind floors** — Green/airy aesthetic, wind-aspected enemies\n\n**Key Mechanics:**\n- All playable characters are available — use your full roster\n- Every 4th floor (4, 8, 12, 16) features a mandatory boss battle\n- Defeating bosses awards **Zemurian Ore Shards** (ultimate weapon materials)\n- The layout reshuffles if you leave, but **defeated bosses do NOT respawn**\n- All characters can use **Overdrive** regardless of Link status\n- Link EXP gained is **tripled** in this dungeon\n\n### Floors 1-4: Earth Theme\n\nClear through the first three floors systematically:\n- Use **Analyze** on every new enemy for Battle Notebook completion\n- Open all treasure chests — they contain endgame-quality gear and quartz\n- Exploit Wind-element weaknesses against Earth-aspected foes\n\n<!-- checkpoint: epi-boss-1 | Defeated Volglyph (Floor 4) -->\n\n**BOSS: Volglyph (Floor 4 — Earth-themed)**\n\nThe first corridor boss. A massive earth elemental with high defense.\n\n**Strategy:**\n- Use Wind-element arts for weakness exploitation\n- Break its earth barriers with repeated strikes\n- Keep party spread to avoid AoE ground attacks\n- Rewards: **Zemurian Ore Shard** (save these for ultimate weapons)\n\n### Floors 5-8: Water Theme\n\nWater-themed floors feature aquatic and ice-based enemies. Use Fire arts liberally.\n\n<!-- checkpoint: epi-boss-2 | Defeated Lindbaum (Floor 8) -->\n\n**BOSS: Lindbaum (Floor 8 — Water-themed)**\n\nA serpentine water boss with freezing attacks.\n\n**Strategy:**\n- Use Fire-element arts for weakness exploitation\n- Equip Freeze-resistance accessories\n- Watch for water-based AoE that can hit the entire party\n- Rewards: **Zemurian Ore Shard**\n\n### Floors 9-12: Fire Theme\n\nFire floors are aggressive with burn-inflicting enemies. Bring Water arts and Burn resistance.\n\n**BOSS: Agnagarn (Floor 12 — Fire-themed)**\n\nA blazing phoenix-like boss with devastating flame attacks.\n\n**Strategy:**\n- Use Water-element arts for weakness exploitation\n- Equip Burn-resistance on all party members\n- The boss can buff its own attack — debuff immediately when this happens\n- Rewards: **Zemurian Ore Shard**\n\n### Floors 13-16: Wind Theme\n\nThe final set of regular floors. Wind enemies are fast — bring Earth arts and speed-boosting quartz.\n\n<!-- checkpoint: epi-boss-4 | Defeated Heidrun (Floor 16) -->\n\n**BOSS: Heidrun (Floor 16 — Wind-themed)**\n\nThe fourth and final corridor boss. Extremely fast with evasion mechanics.\n\n**Strategy:**\n- Use Earth-element arts for weakness exploitation\n- Equip Hit-boosting quartz to counter its evasion\n- Watch for wind-based delays that can push your turns back\n- Rewards: **Zemurian Ore Shard**\n\n### Boundless Cathedral — True Final Boss\n\nAfter clearing floor 16, the path to the **Boundless Cathedral** opens. This is the final challenge.\n\n<!-- checkpoint: epi-final-boss | Entered Boundless Cathedral -->\n\n**SAVE BEFORE ENTERING — there is no return from this point.**\n\n**BOSS: Loa Luciferia (True Final Boss)**\n\nThe ultimate test of everything you've learned. Loa Luciferia is exponentially stronger than anything in the main story.\n\n**Preparation:**\n- Party level 120+ recommended\n- Equip Zemurian Ore weapons (crafted from Shards)\n- Max out Master Quartz levels\n- Full stock of best healing items\n- Status immunity accessories on all members\n\n**Phase 1 — Initial Assault:**\n- Loa Luciferia opens with debuffs and status ailments\n- Immediately buff your party (Attack, Defense, Speed)\n- Keep HP high — it uses powerful all-field arts\n\n**Phase 2 — Summons:**\n- The boss summons smaller orbs that heal it or use strong arts\n- Prioritize destroying summons with AoE S-Crafts\n- Don't let them accumulate or the boss becomes unkillable\n\n**Phase 3 — True Form:**\n- Devastating field-wipe attacks become common\n- Chain Overdrive with S-Crafts for burst damage\n- Use Arts Reflect/Aegis Shield to nullify magic attacks\n- Keep buffs active at ALL times\n- S-Break to interrupt the boss's most dangerous charges\n\n**Victory rewards powerful accessories and unlocks a trophy/achievement.**\n\n### Bonus: Phantasmal Mirrors\n\nSpecial items purchasable in the corridor allow you to transform party members into guest characters for battle — including **Crow**, **Vita**, **Lloyd**, **Rixia**, and **Altina**. These provide unique movesets and are fun for experimentation.\n\nCongratulations on completing The Legend of Heroes: Trails of Cold Steel II!",
+      "checkpoints": [
+        { "id": "epi-enter", "label": "Entered Reverie Corridor" },
+        { "id": "epi-boss-1", "label": "Defeated Volglyph (Floor 4)" },
+        { "id": "epi-boss-2", "label": "Defeated Lindbaum (Floor 8)" },
+        { "id": "epi-boss-4", "label": "Defeated Heidrun (Floor 16)" },
+        { "id": "epi-final-boss", "label": "Entered Boundless Cathedral" }
+      ],
       "steps": [
         {
           "id": "epi-001",
@@ -800,7 +913,7 @@
           "id": "epi-006",
           "type": "boss",
           "text": "**BOSS: Volglyph (Floor 4 — Earth-themed)** — First corridor boss. Rewards Zemurian Ore Shard.",
-          "note": "Use Wind-element arts for weakness exploitation."
+          "note": "Use Wind-element arts for weakness exploitation. Break its earth barriers with repeated strikes."
         },
         {
           "id": "epi-007",
@@ -811,7 +924,7 @@
           "id": "epi-008",
           "type": "boss",
           "text": "**BOSS: Lindbaum (Floor 8 — Water-themed)** — Second corridor boss. Rewards Zemurian Ore Shard.",
-          "note": "Use Fire-element arts for weakness exploitation."
+          "note": "Use Fire-element arts for weakness exploitation. Equip Freeze-resistance accessories."
         },
         {
           "id": "epi-009",
@@ -822,7 +935,7 @@
           "id": "epi-010",
           "type": "boss",
           "text": "**BOSS: Agnagarn (Floor 12 — Fire-themed)** — Third corridor boss. Rewards Zemurian Ore Shard.",
-          "note": "Use Water-element arts for weakness exploitation."
+          "note": "Use Water-element arts for weakness exploitation. Equip Burn-resistance on all party members."
         },
         {
           "id": "epi-011",
@@ -833,7 +946,7 @@
           "id": "epi-012",
           "type": "boss",
           "text": "**BOSS: Heidrun (Floor 16 — Wind-themed)** — Fourth and final corridor boss. Rewards Zemurian Ore Shard.",
-          "note": "Use Earth-element arts for weakness exploitation."
+          "note": "Use Earth-element arts for weakness exploitation. Equip Hit-boosting quartz to counter its evasion."
         },
         {
           "id": "epi-013",
@@ -848,8 +961,8 @@
         {
           "id": "epi-015",
           "type": "boss",
-          "text": "**BOSS: Loa Luciferia (True Final Boss)** — The ultimate test. Ensure your party is fully equipped with the best gear, quartz, and healing items.",
-          "note": "Use Overdrive liberally, keep buffs active at all times, and save S-Crafts for critical moments."
+          "text": "**BOSS: Loa Luciferia (True Final Boss)** — The ultimate test. Level 120+ recommended. Equip Zemurian Ore weapons and status immunity accessories.",
+          "note": "Three phases: Initial assault with debuffs, summoning phase (destroy orbs with AoE), and true form (use Overdrive chains and S-Break interrupts). Keep buffs active at all times."
         },
         {
           "id": "epi-016",

--- a/walkthroughs/walkthrough.schema.json
+++ b/walkthroughs/walkthrough.schema.json
@@ -53,7 +53,7 @@
   "$defs": {
     "section": {
       "type": "object",
-      "required": ["id", "title", "steps"],
+      "required": ["id", "title"],
       "additionalProperties": false,
       "properties": {
         "id": {
@@ -61,10 +61,40 @@
           "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
         },
         "title": { "type": "string" },
+        "content": {
+          "type": "string",
+          "description": "Full walkthrough prose in Markdown. Embed milestone checkpoints with <!-- checkpoint: <id> | <label> --> markers."
+        },
+        "checkpoints": {
+          "type": "array",
+          "description": "Milestone checkpoints referenced in the content field. Each checkpoint id must appear in a <!-- checkpoint: id | label --> marker in content.",
+          "items": { "$ref": "#/$defs/checkpoint" }
+        },
         "steps": {
           "type": "array",
           "minItems": 1,
-          "items": { "$ref": "#/$defs/step" }
+          "items": { "$ref": "#/$defs/step" },
+          "description": "Granular checkable action items. Optional when content is provided."
+        }
+      },
+      "anyOf": [
+        { "required": ["content"] },
+        { "required": ["steps"] }
+      ]
+    },
+    "checkpoint": {
+      "type": "object",
+      "required": ["id", "label"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Unique checkpoint slug, used in <!-- checkpoint: id | label --> markers"
+        },
+        "label": {
+          "type": "string",
+          "description": "Human-readable milestone label, e.g. 'Reached Firelink Shrine'"
         }
       }
     },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "webapp",
 			"version": "0.0.1",
 			"dependencies": {
-				"idb-keyval": "^6.2.2"
+				"idb-keyval": "^6.2.2",
+				"marked": "^18.0.3"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^7.0.1",
@@ -4396,6 +4397,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "18.0.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.3.tgz",
+			"integrity": "sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/math-intrinsics": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,7 +23,8 @@
 		"vite-plugin-pwa": "^1.2.0"
 	},
 	"dependencies": {
-		"idb-keyval": "^6.2.2"
+		"idb-keyval": "^6.2.2",
+		"marked": "^18.0.3"
 	},
 	"overrides": {
 		"cookie": "^1.1.1",

--- a/webapp/src/lib/state.ts
+++ b/webapp/src/lib/state.ts
@@ -32,10 +32,14 @@ export function computeProgress(checkedSteps: Set<string>, totalSteps: number): 
 	return Math.round((checkedSteps.size / totalSteps) * 100);
 }
 
-/** Count all checkable steps (type !== 'note') in a walkthrough. */
-export function countCheckableSteps(sections: { steps: { type: string }[] }[]): number {
+/** Count all checkable items (steps with type !== 'note', plus checkpoints) in a walkthrough. */
+export function countCheckableSteps(sections: { steps?: { type: string }[]; checkpoints?: { id: string }[] }[]): number {
 	return sections.reduce(
-		(total, section) => total + section.steps.filter((s) => s.type !== 'note').length,
+		(total, section) => {
+			const stepCount = (section.steps ?? []).filter((s) => s.type !== 'note').length;
+			const cpCount = (section.checkpoints ?? []).length;
+			return total + stepCount + cpCount;
+		},
 		0
 	);
 }

--- a/webapp/src/lib/types.ts
+++ b/webapp/src/lib/types.ts
@@ -6,10 +6,17 @@ export interface WalkthroughStep {
 	image_url?: string;
 }
 
+export interface WalkthroughCheckpoint {
+	id: string;
+	label: string;
+}
+
 export interface WalkthroughSection {
 	id: string;
 	title: string;
-	steps: WalkthroughStep[];
+	content?: string;
+	checkpoints?: WalkthroughCheckpoint[];
+	steps?: WalkthroughStep[];
 }
 
 export interface Walkthrough {

--- a/webapp/src/routes/[id]/+page.svelte
+++ b/webapp/src/routes/[id]/+page.svelte
@@ -5,6 +5,7 @@
 	import { syncProgress, timeAgo } from '$lib/sync.js';
 	import { GamepadNavigator } from '$lib/gamepad.js';
 	import type { SyncStatus } from '$lib/types.js';
+	import { marked } from 'marked';
 
 	let { data }: { data: PageData } = $props();
 	const wt = $derived(data.walkthrough);
@@ -16,18 +17,21 @@
 	let syncStatus = $state<SyncStatus>({ online: false, lastSynced: null, stale: false, remoteUpdatedAt: null });
 	let showStalePrompt = $state(false);
 	let remoteRecord = $state<{ checkedSteps: string[]; updatedAt: string } | null>(null);
+	let showSteps = $state(false);
+
+	// ── Helpers ────────────────────────────────────────────────────────────────
+	function isCheckableId(id: string): boolean {
+		for (const s of wt.sections) {
+			for (const step of (s.steps ?? [])) if (step.id === id && step.type !== 'note') return true;
+			for (const cp of (s.checkpoints ?? [])) if (cp.id === id) return true;
+		}
+		return false;
+	}
 
 	// ── Derived ────────────────────────────────────────────────────────────────
 	const totalCheckable = $derived(countCheckableSteps(wt.sections));
-	const checkedCount = $derived([...checkedSteps].filter(id => {
-		// Only count checkable steps
-		for (const s of wt.sections) for (const step of s.steps) if (step.id === id && step.type !== 'note') return true;
-		return false;
-	}).length);
-	const progressPct = $derived(computeProgress(new Set([...checkedSteps].filter(id => {
-		for (const s of wt.sections) for (const step of s.steps) if (step.id === id && step.type !== 'note') return true;
-		return false;
-	})), totalCheckable));
+	const checkedCount = $derived([...checkedSteps].filter(isCheckableId).length);
+	const progressPct = $derived(computeProgress(new Set([...checkedSteps].filter(isCheckableId)), totalCheckable));
 
 	const currentSection = $derived(wt.sections[currentSectionIdx]);
 
@@ -58,6 +62,47 @@
 				showStalePrompt = true;
 			}
 		});
+	}
+
+	// ── Toggle checkpoint ──────────────────────────────────────────────────────
+	async function toggleCheckpoint(cpId: string) {
+		const next = new Set(checkedSteps);
+		if (next.has(cpId)) next.delete(cpId);
+		else next.add(cpId);
+		checkedSteps = next;
+		const record = await saveProgress(wt.id, checkedSteps);
+		syncProgress(wt.id, record).then((status) => {
+			syncStatus = status;
+			if (status.stale && status.remoteUpdatedAt) {
+				remoteRecord = null;
+				showStalePrompt = true;
+			}
+		});
+	}
+
+	// ── Markdown rendering with checkpoint placeholders ───────────────────────
+	const CHECKPOINT_RE = /<!--\s*checkpoint:\s*([a-z0-9]+(?:-[a-z0-9]+)*)\s*(?:\|\s*(.*?))?\s*-->/g;
+	const CHECKPOINT_PLACEHOLDER = '___CHECKPOINT___';
+
+	function renderContentHtml(content: string): string {
+		const checkpoints: { id: string; label: string }[] = [];
+		const withPlaceholders = content.replace(CHECKPOINT_RE, (_match, id, label) => {
+			checkpoints.push({ id, label: label?.trim() || id });
+			return `\n\n${CHECKPOINT_PLACEHOLDER}${checkpoints.length - 1}\n\n`;
+		});
+
+		let html = marked.parse(withPlaceholders, { async: false }) as string;
+
+		checkpoints.forEach((cp, idx) => {
+			const placeholder = `${CHECKPOINT_PLACEHOLDER}${idx}`;
+			const placeholderInP = new RegExp(`<p>${placeholder}</p>`, 'g');
+			const placeholderBare = new RegExp(placeholder, 'g');
+			const replacement = `<div class="checkpoint-slot" data-checkpoint-id="${cp.id}" data-checkpoint-label="${cp.label.replace(/"/g, '&quot;')}"></div>`;
+			html = html.replace(placeholderInP, replacement);
+			html = html.replace(placeholderBare, replacement);
+		});
+
+		return html;
 	}
 
 	// ── Stale prompt ──────────────────────────────────────────────────────────
@@ -120,6 +165,40 @@
 	}
 
 	// ── Lifecycle ─────────────────────────────────────────────────────────────
+	let contentEl: HTMLElement | null = null;
+
+	function bindCheckpointSlots() {
+		if (!contentEl) return;
+		const slots = contentEl.querySelectorAll<HTMLElement>('.checkpoint-slot');
+		slots.forEach((slot) => {
+			const cpId = slot.dataset.checkpointId!;
+			const cpLabel = slot.dataset.checkpointLabel!;
+			const isChecked = checkedSteps.has(cpId);
+
+			slot.innerHTML = `
+				<button class="checkpoint-btn ${isChecked ? 'is-checked' : ''}" aria-label="Milestone: ${cpLabel}" role="checkbox" aria-checked="${isChecked}">
+					<span class="checkpoint-check" aria-hidden="true">
+						<svg viewBox="0 0 20 20" fill="none">
+							<rect class="check-bg" x="1" y="1" width="18" height="18" rx="5" />
+							<polyline class="check-mark ${isChecked ? 'checked' : ''}" points="5,10 9,14 15,6" />
+						</svg>
+					</span>
+					<span class="checkpoint-flag" aria-hidden="true">🏁</span>
+					<span class="checkpoint-label">${cpLabel}</span>
+				</button>`;
+
+			const btn = slot.querySelector('button')!;
+			btn.onclick = () => toggleCheckpoint(cpId);
+		});
+	}
+
+	$effect(() => {
+		// Re-bind checkpoints whenever checked state or section changes
+		void checkedSteps;
+		void currentSectionIdx;
+		tick().then(bindCheckpointSlots);
+	});
+
 	onMount(async () => {
 		const record = await loadProgress(wt.id);
 		if (record) checkedSteps = new Set(record.checkedSteps);
@@ -233,52 +312,115 @@
 		</ul>
 	</details>
 
-	<!-- Steps list -->
-	<main class="steps-list" aria-label="Steps for {currentSection?.title}">
-		{#each currentSection?.steps ?? [] as step, i (step.id)}
-			{@const isCheckable = step.type !== 'note'}
-			{@const isChecked = checkedSteps.has(step.id)}
-			{@const isFocused = i === focusedStepIdx}
-			<div
-				class="step-card"
-				class:checkable={isCheckable}
-				class:checked={isChecked}
-				class:focused={isFocused}
-				class:type-note={step.type === 'note'}
-				class:type-warning={step.type === 'warning'}
-				class:type-collectible={step.type === 'collectible'}
-				class:type-boss={step.type === 'boss'}
-				role={isCheckable ? 'checkbox' : undefined}
-				aria-checked={isCheckable ? isChecked : undefined}
-				aria-label="{TYPE_LABEL[step.type]}: {step.text}"
-				tabindex={isCheckable ? 0 : undefined}
-				use:stepAction={i}
-				onclick={() => toggleStep(step.id, step.type)}
-				onkeydown={(e) => { if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); toggleStep(step.id, step.type); }}}
-			>
-				<div class="step-icon-col">
-					<span class="type-badge type-{step.type}" aria-hidden="true">{TYPE_ICON[step.type]}</span>
-					{#if isCheckable}
-						<span class="custom-check" class:is-checked={isChecked} aria-hidden="true">
-							<svg viewBox="0 0 20 20" fill="none">
-								<rect class="check-bg" x="1" y="1" width="18" height="18" rx="5" />
-								<polyline class="check-mark" points="5,10 9,14 15,6" />
-							</svg>
-						</span>
-					{/if}
+	<!-- Section content -->
+	{#if currentSection?.content}
+		<!-- Prose mode: full walkthrough text with embedded checkpoints -->
+		<div class="prose-container" bind:this={contentEl}>
+			{@html renderContentHtml(currentSection.content)}
+		</div>
+
+		<!-- Collapsible granular steps -->
+		{#if currentSection.steps && currentSection.steps.length > 0}
+			<details class="steps-toggle" bind:open={showSteps}>
+				<summary class="steps-toggle-btn">
+					<span class="steps-toggle-icon">{showSteps ? '▼' : '▶'}</span>
+					Detailed steps ({currentSection.steps.filter(s => s.type !== 'note').length} checkable)
+				</summary>
+				<main class="steps-list" aria-label="Detailed steps for {currentSection?.title}">
+					{#each currentSection.steps as step, i (step.id)}
+						{@const isCheckable = step.type !== 'note'}
+						{@const isChecked = checkedSteps.has(step.id)}
+						{@const isFocused = i === focusedStepIdx}
+						<div
+							class="step-card"
+							class:checkable={isCheckable}
+							class:checked={isChecked}
+							class:focused={isFocused}
+							class:type-note={step.type === 'note'}
+							class:type-warning={step.type === 'warning'}
+							class:type-collectible={step.type === 'collectible'}
+							class:type-boss={step.type === 'boss'}
+							role={isCheckable ? 'checkbox' : undefined}
+							aria-checked={isCheckable ? isChecked : undefined}
+							aria-label="{TYPE_LABEL[step.type]}: {step.text}"
+							tabindex={isCheckable ? 0 : undefined}
+							use:stepAction={i}
+							onclick={() => toggleStep(step.id, step.type)}
+							onkeydown={(e) => { if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); toggleStep(step.id, step.type); }}}
+						>
+							<div class="step-icon-col">
+								<span class="type-badge type-{step.type}" aria-hidden="true">{TYPE_ICON[step.type]}</span>
+								{#if isCheckable}
+									<span class="custom-check" class:is-checked={isChecked} aria-hidden="true">
+										<svg viewBox="0 0 20 20" fill="none">
+											<rect class="check-bg" x="1" y="1" width="18" height="18" rx="5" />
+											<polyline class="check-mark" points="5,10 9,14 15,6" />
+										</svg>
+									</span>
+								{/if}
+							</div>
+							<div class="step-body">
+								<p class="step-text">{@html step.text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')}</p>
+								{#if step.note}
+									<p class="step-note">{step.note}</p>
+								{/if}
+								{#if step.image_url}
+									<img class="step-img" src={step.image_url} alt="Screenshot for this step" loading="lazy" />
+								{/if}
+							</div>
+						</div>
+					{/each}
+				</main>
+			</details>
+		{/if}
+	{:else}
+		<!-- Classic mode: step list only -->
+		<main class="steps-list" aria-label="Steps for {currentSection?.title}">
+			{#each currentSection?.steps ?? [] as step, i (step.id)}
+				{@const isCheckable = step.type !== 'note'}
+				{@const isChecked = checkedSteps.has(step.id)}
+				{@const isFocused = i === focusedStepIdx}
+				<div
+					class="step-card"
+					class:checkable={isCheckable}
+					class:checked={isChecked}
+					class:focused={isFocused}
+					class:type-note={step.type === 'note'}
+					class:type-warning={step.type === 'warning'}
+					class:type-collectible={step.type === 'collectible'}
+					class:type-boss={step.type === 'boss'}
+					role={isCheckable ? 'checkbox' : undefined}
+					aria-checked={isCheckable ? isChecked : undefined}
+					aria-label="{TYPE_LABEL[step.type]}: {step.text}"
+					tabindex={isCheckable ? 0 : undefined}
+					use:stepAction={i}
+					onclick={() => toggleStep(step.id, step.type)}
+					onkeydown={(e) => { if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); toggleStep(step.id, step.type); }}}
+				>
+					<div class="step-icon-col">
+						<span class="type-badge type-{step.type}" aria-hidden="true">{TYPE_ICON[step.type]}</span>
+						{#if isCheckable}
+							<span class="custom-check" class:is-checked={isChecked} aria-hidden="true">
+								<svg viewBox="0 0 20 20" fill="none">
+									<rect class="check-bg" x="1" y="1" width="18" height="18" rx="5" />
+									<polyline class="check-mark" points="5,10 9,14 15,6" />
+								</svg>
+							</span>
+						{/if}
+					</div>
+					<div class="step-body">
+						<p class="step-text">{@html step.text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')}</p>
+						{#if step.note}
+							<p class="step-note">{step.note}</p>
+						{/if}
+						{#if step.image_url}
+							<img class="step-img" src={step.image_url} alt="Screenshot for this step" loading="lazy" />
+						{/if}
+					</div>
 				</div>
-				<div class="step-body">
-					<p class="step-text">{@html step.text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')}</p>
-					{#if step.note}
-						<p class="step-note">{step.note}</p>
-					{/if}
-					{#if step.image_url}
-						<img class="step-img" src={step.image_url} alt="Screenshot for this step" loading="lazy" />
-					{/if}
-				</div>
-			</div>
-		{/each}
-	</main>
+			{/each}
+		</main>
+	{/if}
 
 	<!-- Attribution -->
 	<footer class="attribution">
@@ -760,6 +902,205 @@
 	.btn-ghost:hover {
 		border-color: rgba(124,106,247,0.3);
 		color: #a89df7;
+	}
+
+	/* ── Prose container ── */
+	.prose-container {
+		padding: 1rem 1rem 0.5rem;
+		line-height: 1.75;
+		color: #d8d8e8;
+		font-size: 0.94rem;
+	}
+
+	.prose-container :global(h1),
+	.prose-container :global(h2),
+	.prose-container :global(h3) {
+		font-family: 'Rajdhani', system-ui, sans-serif;
+		color: #f0f0ff;
+		margin-top: 1.5rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.prose-container :global(h1) { font-size: 1.6rem; }
+	.prose-container :global(h2) { font-size: 1.3rem; }
+	.prose-container :global(h3) { font-size: 1.1rem; }
+
+	.prose-container :global(p) {
+		margin: 0.75rem 0;
+	}
+
+	.prose-container :global(strong) {
+		color: #f0f0ff;
+	}
+
+	.prose-container :global(em) {
+		color: #a89df7;
+		font-style: italic;
+	}
+
+	.prose-container :global(ul),
+	.prose-container :global(ol) {
+		margin: 0.5rem 0;
+		padding-left: 1.5rem;
+	}
+
+	.prose-container :global(li) {
+		margin: 0.3rem 0;
+	}
+
+	.prose-container :global(blockquote) {
+		border-left: 3px solid rgba(124,106,247,0.4);
+		padding: 0.5rem 1rem;
+		margin: 0.75rem 0;
+		background: rgba(124,106,247,0.05);
+		border-radius: 0 8px 8px 0;
+		color: #a89df7;
+	}
+
+	.prose-container :global(code) {
+		background: rgba(42,42,68,0.6);
+		padding: 0.1rem 0.4rem;
+		border-radius: 4px;
+		font-size: 0.85rem;
+	}
+
+	.prose-container :global(hr) {
+		border: none;
+		border-top: 1px solid rgba(42,42,68,0.6);
+		margin: 1.5rem 0;
+	}
+
+	/* ── Checkpoint buttons (injected into prose) ── */
+	.prose-container :global(.checkpoint-slot) {
+		margin: 1rem 0;
+	}
+
+	.prose-container :global(.checkpoint-btn) {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		width: 100%;
+		background: rgba(124,106,247,0.06);
+		border: 2px solid rgba(124,106,247,0.2);
+		border-radius: 14px;
+		padding: 0.85rem 1rem;
+		cursor: pointer;
+		transition: border-color 0.2s, background 0.2s, box-shadow 0.2s, transform 0.15s;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	.prose-container :global(.checkpoint-btn:hover) {
+		border-color: rgba(124,106,247,0.5);
+		background: rgba(124,106,247,0.1);
+		box-shadow: 0 0 16px rgba(124,106,247,0.1);
+	}
+
+	.prose-container :global(.checkpoint-btn:active) {
+		transform: scale(0.99);
+	}
+
+	.prose-container :global(.checkpoint-btn.is-checked) {
+		border-color: rgba(84,214,106,0.4);
+		background: rgba(84,214,106,0.06);
+	}
+
+	.prose-container :global(.checkpoint-check) {
+		display: block;
+		width: 22px;
+		height: 22px;
+		flex-shrink: 0;
+	}
+
+	.prose-container :global(.checkpoint-check svg) {
+		width: 100%;
+		height: 100%;
+	}
+
+	.prose-container :global(.checkpoint-check .check-bg) {
+		stroke: #3a3a5c;
+		stroke-width: 1.5;
+		fill: rgba(10,10,20,0.5);
+		transition: stroke 0.2s, fill 0.2s;
+	}
+
+	.prose-container :global(.checkpoint-btn.is-checked .check-bg) {
+		stroke: #54d66a;
+		fill: rgba(84,214,106,0.15);
+	}
+
+	.prose-container :global(.checkpoint-check .check-mark) {
+		stroke: #3a3a5c;
+		stroke-width: 2.5;
+		stroke-linecap: round;
+		stroke-linejoin: round;
+		stroke-dasharray: 20;
+		stroke-dashoffset: 20;
+		transition: stroke-dashoffset 0.3s ease, stroke 0.2s;
+	}
+
+	.prose-container :global(.checkpoint-check .check-mark.checked) {
+		stroke-dashoffset: 0;
+		stroke: #54d66a;
+	}
+
+	.prose-container :global(.checkpoint-flag) {
+		font-size: 1.1rem;
+		flex-shrink: 0;
+	}
+
+	.prose-container :global(.checkpoint-label) {
+		font-family: 'Rajdhani', system-ui, sans-serif;
+		font-size: 1rem;
+		font-weight: 600;
+		color: #e8e8f0;
+	}
+
+	.prose-container :global(.checkpoint-btn.is-checked .checkpoint-label) {
+		color: #54d66a;
+	}
+
+	/* ── Steps toggle (collapsible) ── */
+	.steps-toggle {
+		margin: 0.5rem 0.75rem 0;
+		border: 1px solid rgba(42,42,68,0.6);
+		border-radius: 12px;
+		background: rgba(14,14,24,0.6);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
+	}
+
+	:global(body[data-power-save]) .steps-toggle {
+		backdrop-filter: none;
+		-webkit-backdrop-filter: none;
+	}
+
+	.steps-toggle-btn {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.75rem 1rem;
+		font-size: 0.85rem;
+		color: #8888aa;
+		cursor: pointer;
+		list-style: none;
+		user-select: none;
+		transition: color 0.2s;
+	}
+
+	.steps-toggle-btn:hover {
+		color: #a89df7;
+	}
+
+	.steps-toggle-btn::-webkit-details-marker { display: none; }
+
+	.steps-toggle[open] .steps-toggle-btn {
+		border-bottom: 1px solid rgba(42,42,68,0.5);
+		color: #a89df7;
+	}
+
+	.steps-toggle-icon {
+		font-size: 0.7rem;
+		transition: transform 0.2s;
 	}
 
 	@media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Add markdown content field to walkthrough sections, enabling rich full-text walkthroughs with embedded checkpoint markers alongside the existing granular step checklists.

Schema changes:
- Add optional 'content' (markdown) to section definition
- Add optional 'checkpoints' array (id + label) to section definition
- Sections now require either 'content' or 'steps' (or both)

Webapp changes:
- Install 'marked' for markdown rendering
- Parse checkpoint markers in prose and render as interactive buttons
- Show granular steps in a collapsible panel when prose content exists
- Backward compatible: sections without content render as before
- Update countCheckableSteps to include checkpoint milestones

Re-ingested all 3 walkthroughs with full prose:
- Dark Souls Remastered: 2 sections, 13 checkpoints, 39 steps
- Tales of Berseria: 15 sections, 63 checkpoints, 126 steps
- Trails of Cold Steel II: 13 sections, 48 checkpoints, 151 steps

Updated ingestion skill and docs to reflect new format.