### PR TITLE
docs: update all READMEs to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ A touch and controller-optimized PWA for game walkthroughs. Works on Steam Deck,
 | **SvelteKit** | 2.x | PWA framework (Svelte 5, TypeScript 6) |
 | **Vite** | 8.x | Build tool / dev server |
 | **SQLite** | via `modernc.org/sqlite` | Pure-Go, no CGO required |
-| **Docker** | node:22-alpine / golang:1.26.2-alpine | Multi-stage build |
+| **Docker** | node:22-alpine / golang:1.26.2-alpine / alpine:3.23 | Multi-stage build |
 
 ## Repository layout
 
 ```
-.github/copilot/skills/   Copilot walkthrough pipeline skills (writer, reviewer, gamer, completionist)
+.github/copilot/skills/   Copilot walkthrough pipeline skills (writer, reviewer, gamer, completionist, ingest)
 .github/workflows/        CI: schema validation + build/push image + update manifests
 walkthroughs/             Curated walkthrough JSON files
 webapp/                   SvelteKit PWA (TypeScript, Svelte 5)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Requires **Go 1.26+** and **Node 22+**.
 
 ```bash
 # Build the webapp
-cd webapp && npm ci && npm run build && cd ..
+cd webapp && npm ci --legacy-peer-deps && npm run build && cd ..
 
 # Run in file mode (reads from local walkthroughs/ directory)
 cd server

--- a/README.md
+++ b/README.md
@@ -23,12 +23,10 @@ webapp/                   SvelteKit PWA (TypeScript, Svelte 5)
 server/                   Go sync server
 server/k8s/               Kubernetes manifests (synced by ArgoCD)
 server/argocd/            ArgoCD Application manifest (bootstrap only)
-docs/                     Device & troubleshooting guides
+docs/                     Setup guides, device guides, troubleshooting
 ```
 
----
-
-## Architecture: server mode vs client mode
+## Architecture
 
 The Go server runs in one of three modes, controlled by the `APP_MODE` environment variable:
 
@@ -38,134 +36,9 @@ The Go server runs in one of three modes, controlled by the `APP_MODE` environme
 | **Client** | `client` | Fetches from a remote server | Local SQLite + syncs upstream | Handheld devices (Steam Deck, ROG Ally) |
 | **File** | *(unset)* | Reads from local `walkthroughs/` dir | Local SQLite | Local development |
 
-### Server mode
+See [docs/server-setup.md](docs/server-setup.md) and [docs/client-setup.md](docs/client-setup.md) for full setup instructions.
 
-The server is the authoritative source of truth. It runs on your Kubernetes cluster (or any always-on machine) and:
-
-- Polls the GitHub repo for walkthrough JSON files every 5 minutes (configurable via `GITHUB_REFRESH_INTERVAL`)
-- Stores progress in a local SQLite database
-- Serves the PWA webapp to browsers
-- Exposes management APIs under `/api/server/` (ingest jobs, connected devices)
-
-**Required environment variables:**
-
-| Variable | Example | Description |
-|---|---|---|
-| `APP_MODE` | `server` | Enables server mode |
-| `GITHUB_REPO` | `camcast3/walkthrough-app` | GitHub repo in `owner/repo` format |
-| `GITHUB_BRANCH` | `main` | Branch to poll (default: `main`) |
-| `GITHUB_PATH` | `walkthroughs` | Path within the repo (default: `walkthroughs`) |
-| `GITHUB_TOKEN` | *(optional)* | Required for private repos |
-| `GITHUB_REFRESH_INTERVAL` | `5m` | How often to check for new walkthroughs (default: `5m`) |
-| `GITHUB_CACHE_DIR` | `/data` | Directory for cached walkthrough data |
-
-### Client mode
-
-Clients connect to a remote server instance. They cache walkthroughs locally so they work offline, and sync progress bi-directionally:
-
-- Fetches the walkthrough list and content from the remote server every 10 minutes (configurable via `REMOTE_REFRESH_INTERVAL`)
-- Caches walkthrough data to disk for offline use
-- Pushes local progress changes upstream every 30 seconds (configurable via `PROGRESS_SYNC_INTERVAL`)
-- Pulls latest progress from the server on startup
-- Only syncs walkthroughs that are "checked out" on the device
-
-**Required environment variables:**
-
-| Variable | Example | Description |
-|---|---|---|
-| `APP_MODE` | `client` | Enables client mode |
-| `REMOTE_SERVER_URL` | `http://walkthroughs.local.negativezone.cc` | URL of the server instance |
-| `REMOTE_REFRESH_INTERVAL` | `10m` | How often to re-fetch walkthroughs (default: `10m`) |
-| `REMOTE_CACHE_DIR` | `/data` | Directory for cached walkthrough data |
-| `PROGRESS_SYNC_INTERVAL` | `30s` | How often to push progress upstream (default: `30s`) |
-
-### Common environment variables (all modes)
-
-| Variable | Flag | Default | Description |
-|---|---|---|---|
-| `DB_PATH` | `--db` | `/data/progress.sqlite` | Path to SQLite database file |
-| `STATIC_DIR` | `--static` | `/static` | Path to built webapp static files |
-| `LISTEN_ADDR` | `--addr` | `:8080` | Listen address |
-| `WALKTHROUGHS_DIR` | `--walkthroughs` | `/walkthroughs` | Local walkthrough directory (file mode only) |
-
-### API routes
-
-| Endpoint | Method | Description | Mode |
-|---|---|---|---|
-| `/api/config` | GET | App configuration (mode, features) | All |
-| `/api/walkthroughs` | GET | List all walkthrough metadata | All |
-| `/api/walkthroughs/{id}` | GET | Get full walkthrough content | All |
-| `/api/progress/{id}` | GET | Get progress for a walkthrough | All |
-| `/api/progress/{id}` | PUT | Save progress for a walkthrough | All |
-| `/api/checkouts` | GET | List checked-out walkthroughs | All |
-| `/api/checkouts/{id}` | PUT | Check out a walkthrough | All |
-| `/api/checkouts/{id}` | DELETE | Remove a checkout | All |
-| `/api/server/ingest` | POST | Start a walkthrough ingest job | Server only |
-| `/api/server/ingest` | GET | List ingest jobs | Server only |
-| `/api/server/ingest/{id}` | GET | Get ingest job status | Server only |
-| `/api/server/devices` | GET | List connected devices | Server only |
-
----
-
-## Setting up the server
-
-### Option 1: Kubernetes (recommended for always-on)
-
-#### Cluster prerequisites
-
-| Component | Role |
-|---|---|
-| **ArgoCD** | GitOps — watches `server/k8s/` on `main` and applies changes automatically |
-| **Argo Rollouts** | Replaces standard Deployments; `Recreate` strategy used (required for RWO PVC) |
-| **Cilium Gateway API** | Ingress via `HTTPRoute` — no nginx ingress needed |
-| **Rook Ceph** | Block storage for the SQLite PVC (`storageClassName: rook-ceph-block`) |
-
-#### One-time setup
-
-**1. Register with ArgoCD** (run once from any machine with cluster access):
-```bash
-kubectl apply -f server/argocd/app.yaml -n argocd
-```
-
-ArgoCD will create the `walkthroughs` namespace, apply all manifests in `server/k8s/`, and watch this repo for changes going forward.
-
-**2. Allow GitHub Actions to push commits back** (needed for manifest updates):
-- Repo **Settings → Actions → General → Workflow permissions → Read and write permissions**
-
-#### How CI/CD works
-
-On every push to `main` the workflow (`.github/workflows/deploy.yml`):
-1. Builds the multi-stage Docker image (SvelteKit webapp + Go server)
-2. Pushes the image to `ghcr.io/camcast3/walkthrough-server` (tagged with commit SHA)
-3. Updates the image tag in `server/k8s/rollout.yaml`
-4. Commits that change back to `main` with `[skip ci]`
-
-ArgoCD detects the new commit and syncs — triggering a Rollout with `Recreate` strategy.
-
-> **No `KUBECONFIG` secret required.** ArgoCD handles all cluster operations. Walkthroughs are fetched at runtime from GitHub (no ConfigMaps).
-
-#### Kubernetes manifests
-
-| File | Kind | Purpose |
-|---|---|---|
-| `server/k8s/rollout.yaml` | `argoproj.io/v1alpha1/Rollout` | App workload; canary with maxSurge=0 for RWO PVC |
-| `server/k8s/service.yaml` | `Service` | ClusterIP on port 80 → container 8080 |
-| `server/k8s/httproute.yaml` | `gateway.networking.k8s.io/v1/HTTPRoute` | Cilium Gateway API routing |
-| `server/k8s/pvc.yaml` | `PersistentVolumeClaim` | 1 Gi `rook-ceph-block` volume for SQLite + cache |
-| `server/argocd/app.yaml` | `argoproj.io/v1alpha1/Application` | ArgoCD app definition (add to app-of-apps) |
-
-### Option 2: Docker Compose
-
-```bash
-# Build the webapp first (the compose file mounts ./webapp/build)
-cd webapp && npm ci && npm run build && cd ..
-
-docker compose up
-```
-
-The server is available at `http://localhost:8080`. The default `docker-compose.yml` runs in **client mode** — set `APP_MODE=server` and add `GITHUB_REPO` to run as a server.
-
-### Option 3: Run directly (no Docker)
+## Quick start (development)
 
 Requires **Go 1.26+** and **Node 22+**.
 
@@ -184,115 +57,18 @@ go run . \
 
 Open `http://localhost:8080`.
 
-To run in server mode instead:
+## Documentation
 
-```bash
-APP_MODE=server \
-GITHUB_REPO=camcast3/walkthrough-app \
-DB_PATH=../data/progress.sqlite \
-STATIC_DIR=../webapp/build \
-go run . --addr :8080
-```
-
-#### Updating walkthroughs
-
-Push JSON files to `walkthroughs/<game>/` in this repo. The server (running in `server` mode) polls the GitHub Trees API every 5 minutes and picks up changes automatically — no image rebuild or redeployment needed.
-
----
-
-## Setting up clients
-
-Clients run on devices where you play games. They connect to your server, cache walkthroughs for offline use, and sync progress.
-
-### Option 1: Browser only (no local server)
-
-If your server is accessible over the network, just open the URL in a browser:
-
-1. Navigate to your server URL (e.g. `https://walkthroughs.yourdomain.com`)
-2. Install as a PWA via the browser menu for a native app experience
-3. The service worker caches the app for offline use after first load
-
-### Option 2: Local client server (recommended for handhelds)
-
-Running a local client server on the device gives you full offline support with background sync. This is the recommended setup for Steam Deck, ROG Ally, and other handhelds running Bazzite.
-
-#### On a handheld running Bazzite (Steam Deck / ROG Ally)
-
-**Prerequisites:**
-- Bazzite installed on the device
-- Your walkthrough server deployed and accessible on the network
-- `podman` available (pre-installed on Bazzite)
-
-**1. Pull and run the container:**
-
-```bash
-podman pull ghcr.io/camcast3/walkthrough-server:latest
-
-podman run -d \
-  --name walkthroughs \
-  --restart unless-stopped \
-  -p 8080:8080 \
-  -e APP_MODE=client \
-  -e REMOTE_SERVER_URL=http://walkthroughs.yourdomain.com \
-  -e DB_PATH=/data/progress.sqlite \
-  -e REMOTE_CACHE_DIR=/data \
-  -e STATIC_DIR=/static \
-  -v walkthrough-data:/data \
-  ghcr.io/camcast3/walkthrough-server:latest
-```
-
-**2. Auto-start on boot (systemd user service):**
-
-```bash
-mkdir -p ~/.config/systemd/user
-podman generate systemd --name walkthroughs --new > ~/.config/systemd/user/walkthroughs.service
-systemctl --user enable walkthroughs.service
-systemctl --user start walkthroughs.service
-```
-
-**3. Add to Steam Game Mode:**
-
-1. Switch to Desktop Mode
-2. Open Steam → **Games → Add a Non-Steam Game → Browse**
-3. Find your browser (e.g. `/usr/bin/chromium-browser` or `flatpak run org.mozilla.firefox`)
-4. Set **Launch Options** to: `--new-window --app=http://localhost:8080`
-5. Rename the shortcut to **"Walkthroughs"**
-
-Now you can switch to the Walkthroughs app mid-game using the Steam button.
-
-#### On Windows
-
-See [docs/windows-setup.md](docs/windows-setup.md) for running the server locally on Windows.
-
-### Device setup guides
-
-| Device | Guide |
+| Guide | Description |
 |---|---|
-| Windows PC | [docs/windows-setup.md](docs/windows-setup.md) |
-| Steam Deck (Bazzite) | [docs/steam-deck-setup.md](docs/steam-deck-setup.md) |
-| ROG Ally (Bazzite) | [docs/rog-ally-setup.md](docs/rog-ally-setup.md) |
-
-### Power-save mode
-
-Handheld devices (ROG Ally, Steam Deck) benefit from automatic power-save mode. When the server is running with `APP_MODE=client` (or is unreachable/offline), the webapp disables GPU-heavy effects:
-
-- Background mesh animations and progress bar shimmer
-- `backdrop-filter: blur()` on cards and UI elements
-- Gamepad polling reduced from 60fps to ~15fps (active only when a gamepad is connected and the page is visible)
-
-NAS/server deployments (`APP_MODE=server` or default) keep all visual effects enabled. The server exposes its mode via `GET /api/config` and the webapp reads it on load.
-
----
-
-## Adding walkthroughs
-
-See [docs/adding-a-walkthrough.md](docs/adding-a-walkthrough.md) for the full walkthrough pipeline, or use the **Copilot walkthrough ingestion skill** (`.github/copilot/skills/walkthrough-ingest.md`) for a quick single-pass conversion.
-
-The full pipeline uses four Copilot agents:
-
-```
-Writer  →  Reviewer  →  Gamer  →  Completionist
-```
+| [docs/server-setup.md](docs/server-setup.md) | Deploying the server (Kubernetes, Docker Compose, bare metal) |
+| [docs/client-setup.md](docs/client-setup.md) | Setting up clients (browser PWA, local client server, Bazzite handhelds) |
+| [docs/steam-deck-setup.md](docs/steam-deck-setup.md) | Steam Deck device-specific guide |
+| [docs/rog-ally-setup.md](docs/rog-ally-setup.md) | ROG Ally device-specific guide |
+| [docs/windows-setup.md](docs/windows-setup.md) | Windows PC guide |
+| [docs/adding-a-walkthrough.md](docs/adding-a-walkthrough.md) | Walkthrough creation pipeline (4-agent Copilot workflow) |
+| [docs/e2e-test-plan.md](docs/e2e-test-plan.md) | Manual E2E test plan for server/client mode |
+| [docs/tsg-httproute-not-accepted.md](docs/tsg-httproute-not-accepted.md) | Troubleshooting: Cilium HTTPRoute not accepted |
 
 ## Walkthrough format
 

--- a/README.md
+++ b/README.md
@@ -2,24 +2,116 @@
 
 A touch and controller-optimized PWA for game walkthroughs. Works on Steam Deck, ROG Ally (Bazzite), and Windows PC. Syncs progress to a self-hosted server when online; works fully offline via service worker.
 
+## Tech stack & versions
+
+| Component | Version | Notes |
+|---|---|---|
+| **Go** | 1.26+ | Server binary (`server/`) |
+| **Node.js** | 22+ | Webapp build tooling |
+| **SvelteKit** | 2.x | PWA framework (Svelte 5, TypeScript 6) |
+| **Vite** | 8.x | Build tool / dev server |
+| **SQLite** | via `modernc.org/sqlite` | Pure-Go, no CGO required |
+| **Docker** | node:22-alpine / golang:1.26.2-alpine | Multi-stage build |
+
 ## Repository layout
 
 ```
-.github/copilot/skills/   Copilot walkthrough ingestion skill
+.github/copilot/skills/   Copilot walkthrough pipeline skills (writer, reviewer, gamer, completionist)
 .github/workflows/        CI: schema validation + build/push image + update manifests
 walkthroughs/             Curated walkthrough JSON files
-webapp/                   SvelteKit PWA (TypeScript)
+webapp/                   SvelteKit PWA (TypeScript, Svelte 5)
 server/                   Go sync server
 server/k8s/               Kubernetes manifests (synced by ArgoCD)
 server/argocd/            ArgoCD Application manifest (bootstrap only)
-docs/                     Device setup guides
+docs/                     Device & troubleshooting guides
 ```
 
 ---
 
-## Deploying to Kubernetes
+## Architecture: server mode vs client mode
 
-### Cluster prerequisites
+The Go server runs in one of three modes, controlled by the `APP_MODE` environment variable:
+
+| Mode | `APP_MODE` | Walkthrough source | Progress storage | Use case |
+|---|---|---|---|---|
+| **Server** | `server` | Polls GitHub Trees API | Local SQLite (authoritative) | Kubernetes / NAS — central hub |
+| **Client** | `client` | Fetches from a remote server | Local SQLite + syncs upstream | Handheld devices (Steam Deck, ROG Ally) |
+| **File** | *(unset)* | Reads from local `walkthroughs/` dir | Local SQLite | Local development |
+
+### Server mode
+
+The server is the authoritative source of truth. It runs on your Kubernetes cluster (or any always-on machine) and:
+
+- Polls the GitHub repo for walkthrough JSON files every 5 minutes (configurable via `GITHUB_REFRESH_INTERVAL`)
+- Stores progress in a local SQLite database
+- Serves the PWA webapp to browsers
+- Exposes management APIs under `/api/server/` (ingest jobs, connected devices)
+
+**Required environment variables:**
+
+| Variable | Example | Description |
+|---|---|---|
+| `APP_MODE` | `server` | Enables server mode |
+| `GITHUB_REPO` | `camcast3/walkthrough-app` | GitHub repo in `owner/repo` format |
+| `GITHUB_BRANCH` | `main` | Branch to poll (default: `main`) |
+| `GITHUB_PATH` | `walkthroughs` | Path within the repo (default: `walkthroughs`) |
+| `GITHUB_TOKEN` | *(optional)* | Required for private repos |
+| `GITHUB_REFRESH_INTERVAL` | `5m` | How often to check for new walkthroughs (default: `5m`) |
+| `GITHUB_CACHE_DIR` | `/data` | Directory for cached walkthrough data |
+
+### Client mode
+
+Clients connect to a remote server instance. They cache walkthroughs locally so they work offline, and sync progress bi-directionally:
+
+- Fetches the walkthrough list and content from the remote server every 10 minutes (configurable via `REMOTE_REFRESH_INTERVAL`)
+- Caches walkthrough data to disk for offline use
+- Pushes local progress changes upstream every 30 seconds (configurable via `PROGRESS_SYNC_INTERVAL`)
+- Pulls latest progress from the server on startup
+- Only syncs walkthroughs that are "checked out" on the device
+
+**Required environment variables:**
+
+| Variable | Example | Description |
+|---|---|---|
+| `APP_MODE` | `client` | Enables client mode |
+| `REMOTE_SERVER_URL` | `http://walkthroughs.local.negativezone.cc` | URL of the server instance |
+| `REMOTE_REFRESH_INTERVAL` | `10m` | How often to re-fetch walkthroughs (default: `10m`) |
+| `REMOTE_CACHE_DIR` | `/data` | Directory for cached walkthrough data |
+| `PROGRESS_SYNC_INTERVAL` | `30s` | How often to push progress upstream (default: `30s`) |
+
+### Common environment variables (all modes)
+
+| Variable | Flag | Default | Description |
+|---|---|---|---|
+| `DB_PATH` | `--db` | `/data/progress.sqlite` | Path to SQLite database file |
+| `STATIC_DIR` | `--static` | `/static` | Path to built webapp static files |
+| `LISTEN_ADDR` | `--addr` | `:8080` | Listen address |
+| `WALKTHROUGHS_DIR` | `--walkthroughs` | `/walkthroughs` | Local walkthrough directory (file mode only) |
+
+### API routes
+
+| Endpoint | Method | Description | Mode |
+|---|---|---|---|
+| `/api/config` | GET | App configuration (mode, features) | All |
+| `/api/walkthroughs` | GET | List all walkthrough metadata | All |
+| `/api/walkthroughs/{id}` | GET | Get full walkthrough content | All |
+| `/api/progress/{id}` | GET | Get progress for a walkthrough | All |
+| `/api/progress/{id}` | PUT | Save progress for a walkthrough | All |
+| `/api/checkouts` | GET | List checked-out walkthroughs | All |
+| `/api/checkouts/{id}` | PUT | Check out a walkthrough | All |
+| `/api/checkouts/{id}` | DELETE | Remove a checkout | All |
+| `/api/server/ingest` | POST | Start a walkthrough ingest job | Server only |
+| `/api/server/ingest` | GET | List ingest jobs | Server only |
+| `/api/server/ingest/{id}` | GET | Get ingest job status | Server only |
+| `/api/server/devices` | GET | List connected devices | Server only |
+
+---
+
+## Setting up the server
+
+### Option 1: Kubernetes (recommended for always-on)
+
+#### Cluster prerequisites
 
 | Component | Role |
 |---|---|
@@ -28,19 +120,19 @@ docs/                     Device setup guides
 | **Cilium Gateway API** | Ingress via `HTTPRoute` — no nginx ingress needed |
 | **Rook Ceph** | Block storage for the SQLite PVC (`storageClassName: rook-ceph-block`) |
 
-### One-time setup
+#### One-time setup
 
 **1. Register with ArgoCD** (run once from any machine with cluster access):
 ```bash
 kubectl apply -f server/argocd/app.yaml -n argocd
 ```
 
-ArgoCD will create the `walkthroughs` namespace, apply all manifests in `server/k8s/`, and watch this repo for changes going forward. No need to add anything to `the-basement`.
+ArgoCD will create the `walkthroughs` namespace, apply all manifests in `server/k8s/`, and watch this repo for changes going forward.
 
 **2. Allow GitHub Actions to push commits back** (needed for manifest updates):
 - Repo **Settings → Actions → General → Workflow permissions → Read and write permissions**
 
-### How CI/CD works
+#### How CI/CD works
 
 On every push to `main` the workflow (`.github/workflows/deploy.yml`):
 1. Builds the multi-stage Docker image (SvelteKit webapp + Go server)
@@ -52,7 +144,7 @@ ArgoCD detects the new commit and syncs — triggering a Rollout with `Recreate`
 
 > **No `KUBECONFIG` secret required.** ArgoCD handles all cluster operations. Walkthroughs are fetched at runtime from GitHub (no ConfigMaps).
 
-### Kubernetes manifests
+#### Kubernetes manifests
 
 | File | Kind | Purpose |
 |---|---|---|
@@ -62,21 +154,26 @@ ArgoCD detects the new commit and syncs — triggering a Rollout with `Recreate`
 | `server/k8s/pvc.yaml` | `PersistentVolumeClaim` | 1 Gi `rook-ceph-block` volume for SQLite + cache |
 | `server/argocd/app.yaml` | `argoproj.io/v1alpha1/Application` | ArgoCD app definition (add to app-of-apps) |
 
-### Updating walkthroughs
+### Option 2: Docker Compose
 
-Push JSON files to `walkthroughs/<game>/` in this repo. The server (running in `server` mode on the cluster) polls the GitHub Trees API every 5 minutes and picks up changes automatically — no image rebuild or redeployment needed.
+```bash
+# Build the webapp first (the compose file mounts ./webapp/build)
+cd webapp && npm ci && npm run build && cd ..
 
----
+docker compose up
+```
 
-## Running locally (without Docker)
+The server is available at `http://localhost:8080`. The default `docker-compose.yml` runs in **client mode** — set `APP_MODE=server` and add `GITHUB_REPO` to run as a server.
 
-Requires Go 1.21+ and Node 18+.
+### Option 3: Run directly (no Docker)
+
+Requires **Go 1.26+** and **Node 22+**.
 
 ```bash
 # Build the webapp
 cd webapp && npm ci && npm run build && cd ..
 
-# Run the server
+# Run in file mode (reads from local walkthroughs/ directory)
 cd server
 go run . \
   --addr :8080 \
@@ -87,20 +184,87 @@ go run . \
 
 Open `http://localhost:8080`.
 
-## Running with Docker Compose
+To run in server mode instead:
 
 ```bash
-# Build the webapp first (the compose file mounts ./webapp/build)
-cd webapp && npm ci && npm run build && cd ..
-
-docker compose up
+APP_MODE=server \
+GITHUB_REPO=camcast3/walkthrough-app \
+DB_PATH=../data/progress.sqlite \
+STATIC_DIR=../webapp/build \
+go run . --addr :8080
 ```
 
-The server is available at `http://localhost:8080`.
+#### Updating walkthroughs
+
+Push JSON files to `walkthroughs/<game>/` in this repo. The server (running in `server` mode) polls the GitHub Trees API every 5 minutes and picks up changes automatically — no image rebuild or redeployment needed.
 
 ---
 
-## Device setup guides
+## Setting up clients
+
+Clients run on devices where you play games. They connect to your server, cache walkthroughs for offline use, and sync progress.
+
+### Option 1: Browser only (no local server)
+
+If your server is accessible over the network, just open the URL in a browser:
+
+1. Navigate to your server URL (e.g. `https://walkthroughs.yourdomain.com`)
+2. Install as a PWA via the browser menu for a native app experience
+3. The service worker caches the app for offline use after first load
+
+### Option 2: Local client server (recommended for handhelds)
+
+Running a local client server on the device gives you full offline support with background sync. This is the recommended setup for Steam Deck, ROG Ally, and other handhelds running Bazzite.
+
+#### On a handheld running Bazzite (Steam Deck / ROG Ally)
+
+**Prerequisites:**
+- Bazzite installed on the device
+- Your walkthrough server deployed and accessible on the network
+- `podman` available (pre-installed on Bazzite)
+
+**1. Pull and run the container:**
+
+```bash
+podman pull ghcr.io/camcast3/walkthrough-server:latest
+
+podman run -d \
+  --name walkthroughs \
+  --restart unless-stopped \
+  -p 8080:8080 \
+  -e APP_MODE=client \
+  -e REMOTE_SERVER_URL=http://walkthroughs.yourdomain.com \
+  -e DB_PATH=/data/progress.sqlite \
+  -e REMOTE_CACHE_DIR=/data \
+  -e STATIC_DIR=/static \
+  -v walkthrough-data:/data \
+  ghcr.io/camcast3/walkthrough-server:latest
+```
+
+**2. Auto-start on boot (systemd user service):**
+
+```bash
+mkdir -p ~/.config/systemd/user
+podman generate systemd --name walkthroughs --new > ~/.config/systemd/user/walkthroughs.service
+systemctl --user enable walkthroughs.service
+systemctl --user start walkthroughs.service
+```
+
+**3. Add to Steam Game Mode:**
+
+1. Switch to Desktop Mode
+2. Open Steam → **Games → Add a Non-Steam Game → Browse**
+3. Find your browser (e.g. `/usr/bin/chromium-browser` or `flatpak run org.mozilla.firefox`)
+4. Set **Launch Options** to: `--new-window --app=http://localhost:8080`
+5. Rename the shortcut to **"Walkthroughs"**
+
+Now you can switch to the Walkthroughs app mid-game using the Steam button.
+
+#### On Windows
+
+See [docs/windows-setup.md](docs/windows-setup.md) for running the server locally on Windows.
+
+### Device setup guides
 
 | Device | Guide |
 |---|---|
@@ -122,7 +286,13 @@ NAS/server deployments (`APP_MODE=server` or default) keep all visual effects en
 
 ## Adding walkthroughs
 
-See [docs/adding-a-walkthrough.md](docs/adding-a-walkthrough.md) for the manual process, or use the **Copilot walkthrough ingestion skill** (`.github/copilot/skills/walkthrough-ingest.md`) to have Copilot convert any online walkthrough into the correct JSON format automatically.
+See [docs/adding-a-walkthrough.md](docs/adding-a-walkthrough.md) for the full walkthrough pipeline, or use the **Copilot walkthrough ingestion skill** (`.github/copilot/skills/walkthrough-ingest.md`) for a quick single-pass conversion.
+
+The full pipeline uses four Copilot agents:
+
+```
+Writer  →  Reviewer  →  Gamer  →  Completionist
+```
 
 ## Walkthrough format
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -1,0 +1,169 @@
+# Client Setup
+
+This guide covers setting up devices that connect to your walkthrough server — handhelds (Steam Deck, ROG Ally), PCs, or any browser.
+
+## How client mode works
+
+A client fetches walkthroughs from the remote server and caches them locally for offline use. Progress is stored in a local SQLite database and synced bi-directionally with the server:
+
+- Fetches the walkthrough list and checked-out content from the server on a configurable interval (default: every 10 minutes)
+- Caches walkthrough data to disk so the app works fully offline
+- Pushes local progress changes upstream (default: every 30 seconds)
+- Pulls latest progress from the server on startup
+- Only syncs walkthroughs that are "checked out" on the device
+
+---
+
+## Option 1: Browser only (recommended)
+
+The simplest setup — no local server needed. Just point a browser at your walkthrough server:
+
+1. Open **Chromium** or **Chrome** (recommended — best Gamepad API and controller support out of the box)
+2. Navigate to your server URL (e.g. `https://walkthroughs.yourdomain.com`)
+3. Install as a PWA: click the install icon in the address bar, or menu → **Install App**
+4. The service worker caches the app and walkthrough data for offline use after first load
+
+> **Why Chromium?** Chromium-based browsers (Chrome, Edge, Chromium) have the most complete Gamepad API implementation and support WebHID for low-latency controller input. Firefox supports the basic Gamepad API but lacks WebHID and may gate controller data behind user interaction. For handheld devices where controller navigation is primary, Chromium gives the best experience.
+
+This is the recommended approach for most users. The PWA works offline, syncs progress when back online, and uses minimal system resources.
+
+### Device-specific guides
+
+| Device | Guide |
+|---|---|
+| Steam Deck (Bazzite) | [steam-deck-setup.md](steam-deck-setup.md) |
+| ROG Ally (Bazzite) | [rog-ally-setup.md](rog-ally-setup.md) |
+| Windows PC | [windows-setup.md](windows-setup.md) |
+
+---
+
+## Option 2: Local client server (advanced)
+
+Running a local client server gives you a dedicated background service that keeps walkthroughs synced even when the browser isn't open. This is useful if you want:
+
+- Background sync without the browser running
+- A local API endpoint for other tools
+- Full control over caching and sync intervals
+
+> **Power note:** The Go server binary is lightweight (~15 MB, ~10-20 MB RAM at runtime). On handhelds, the overhead is negligible compared to the games you're running.
+
+### On a handheld running Bazzite (Steam Deck / ROG Ally)
+
+Bazzite is an immutable (atomic) OS, so the easiest way to run the server is by extracting the pre-built binary from the container image.
+
+**1. Extract the server binary:**
+
+```bash
+# Pull the image and copy the binary out
+podman create --name wt-extract ghcr.io/camcast3/walkthrough-server:latest
+podman cp wt-extract:/app/walkthrough-server ~/.local/bin/walkthrough-server
+podman cp wt-extract:/static ~/.local/share/walkthrough-app/static
+podman rm wt-extract
+
+chmod +x ~/.local/bin/walkthrough-server
+```
+
+**2. Create a systemd user service:**
+
+```bash
+mkdir -p ~/.config/systemd/user
+cat > ~/.config/systemd/user/walkthroughs.service << 'EOF'
+[Unit]
+Description=Walkthrough client server
+After=network-online.target
+Wants=network-online.target
+
+# Don't block boot — start after network is available but don't fail if it isn't
+[Service]
+Type=exec
+ExecStart=%h/.local/bin/walkthrough-server
+Environment=APP_MODE=client
+Environment=REMOTE_SERVER_URL=http://walkthroughs.yourdomain.com
+Environment=DB_PATH=%h/.local/share/walkthrough-app/progress.sqlite
+Environment=REMOTE_CACHE_DIR=%h/.local/share/walkthrough-app
+Environment=STATIC_DIR=%h/.local/share/walkthrough-app/static
+Environment=LISTEN_ADDR=:8080
+
+# Graceful startup — don't hang boot if the network or server is unreachable
+TimeoutStartSec=10
+TimeoutStopSec=5
+
+# Auto-restart on failure, but with backoff to avoid spinning
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+```
+
+**3. Enable and start:**
+
+```bash
+mkdir -p ~/.local/share/walkthrough-app
+systemctl --user daemon-reload
+systemctl --user enable walkthroughs.service
+systemctl --user start walkthroughs.service
+
+# Verify it's running
+systemctl --user status walkthroughs.service
+curl -s http://localhost:8080/api/config | head
+```
+
+> **Boot safety:** The service uses `TimeoutStartSec=10` and `Restart=on-failure` with a 10-second backoff. If the remote server is unreachable on boot, the server starts anyway and serves cached data. It will never hang the boot process.
+
+**4. Add to Steam Game Mode:**
+
+1. Switch to Desktop Mode
+2. Open Steam → **Games → Add a Non-Steam Game → Browse**
+3. Find Chromium (e.g. `/usr/bin/chromium-browser` or `flatpak run com.github.nickvergessen.chromium`)
+4. Set **Launch Options** to: `--new-window --app=http://localhost:8080`
+5. Rename the shortcut to **"Walkthroughs"**
+
+### Updating the binary
+
+When a new version is released, re-extract from the latest image:
+
+```bash
+systemctl --user stop walkthroughs.service
+podman pull ghcr.io/camcast3/walkthrough-server:latest
+podman create --name wt-extract ghcr.io/camcast3/walkthrough-server:latest
+podman cp wt-extract:/app/walkthrough-server ~/.local/bin/walkthrough-server
+podman cp wt-extract:/static ~/.local/share/walkthrough-app/static
+podman rm wt-extract
+systemctl --user start walkthroughs.service
+```
+
+### On Windows
+
+See [windows-setup.md](windows-setup.md) for running the server locally on Windows.
+
+---
+
+## Environment variables
+
+These variables configure client mode. They are currently set via environment variables or CLI flags.
+
+> **Future:** `REMOTE_SERVER_URL`, `REMOTE_REFRESH_INTERVAL`, and `PROGRESS_SYNC_INTERVAL` will be configurable from the webapp settings UI so you can adjust them without restarting the server.
+
+| Variable | Example | Description |
+|---|---|---|
+| `APP_MODE` | `client` | **Required.** Enables client mode |
+| `REMOTE_SERVER_URL` | `http://walkthroughs.local.negativezone.cc` | **Required.** URL of the walkthrough server |
+| `REMOTE_REFRESH_INTERVAL` | `10m` | How often to re-fetch walkthroughs from the server (default: `10m`) |
+| `REMOTE_CACHE_DIR` | `/data` | Local directory for caching walkthrough data fetched from the server |
+| `PROGRESS_SYNC_INTERVAL` | `30s` | How often to push progress changes to the server (default: `30s`) |
+
+Common variables (`DB_PATH`, `STATIC_DIR`, `LISTEN_ADDR`) are documented in [server-setup.md](server-setup.md#common-variables-all-modes).
+
+---
+
+## Power-save mode
+
+Handheld devices benefit from automatic power-save mode. When the server runs in client mode (`APP_MODE=client`) or is unreachable (offline), the webapp disables GPU-heavy effects:
+
+- Background mesh animations and progress bar shimmer
+- `backdrop-filter: blur()` on cards and UI elements
+- Gamepad polling reduced from 60fps to ~15fps (active only when a gamepad is connected and the page is visible)
+
+NAS/server deployments (`APP_MODE=server` or default) keep all visual effects enabled. The server exposes its mode via `GET /api/config` and the webapp reads it on load. No configuration needed on the device — it happens automatically.

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -14,36 +14,13 @@ A client fetches walkthroughs from the remote server and caches them locally for
 
 ---
 
-## Option 1: Browser only (recommended)
+## Option 1: Local client server (recommended for handhelds)
 
-The simplest setup — no local server needed. Just point a browser at your walkthrough server:
+Running a local client server gives you a dedicated background service that keeps walkthroughs synced even when the browser isn't open. This is the recommended setup for Steam Deck, ROG Ally, and other handhelds running Bazzite because it:
 
-1. Open **Chromium** or **Chrome** (recommended — best Gamepad API and controller support out of the box)
-2. Navigate to your server URL (e.g. `https://walkthroughs.yourdomain.com`)
-3. Install as a PWA: click the install icon in the address bar, or menu → **Install App**
-4. The service worker caches the app and walkthrough data for offline use after first load
-
-> **Why Chromium?** Chromium-based browsers (Chrome, Edge, Chromium) have the most complete Gamepad API implementation and support WebHID for low-latency controller input. Firefox supports the basic Gamepad API but lacks WebHID and may gate controller data behind user interaction. For handheld devices where controller navigation is primary, Chromium gives the best experience.
-
-This is the recommended approach for most users. The PWA works offline, syncs progress when back online, and uses minimal system resources.
-
-### Device-specific guides
-
-| Device | Guide |
-|---|---|
-| Steam Deck (Bazzite) | [steam-deck-setup.md](steam-deck-setup.md) |
-| ROG Ally (Bazzite) | [rog-ally-setup.md](rog-ally-setup.md) |
-| Windows PC | [windows-setup.md](windows-setup.md) |
-
----
-
-## Option 2: Local client server (advanced)
-
-Running a local client server gives you a dedicated background service that keeps walkthroughs synced even when the browser isn't open. This is useful if you want:
-
-- Background sync without the browser running
-- A local API endpoint for other tools
-- Full control over caching and sync intervals
+- Syncs walkthroughs in the background — data is always ready when you switch to the app mid-game
+- Works fully offline without needing to have opened the browser first
+- Gives you full control over caching and sync intervals
 
 > **Power note:** The Go server binary is lightweight (~15 MB, ~10-20 MB RAM at runtime). On handhelds, the overhead is negligible compared to the games you're running.
 
@@ -137,6 +114,27 @@ systemctl --user start walkthroughs.service
 ### On Windows
 
 See [windows-setup.md](windows-setup.md) for running the server locally on Windows.
+
+---
+
+## Option 2: Browser only (no local server)
+
+If you don't want to run a local server, you can access the app directly from your walkthrough server over the network. This is a simpler setup but requires the server to be reachable for the initial load:
+
+1. Open **Chromium** or **Chrome** (recommended — best Gamepad API and controller support out of the box)
+2. Navigate to your server URL (e.g. `https://walkthroughs.yourdomain.com`)
+3. Install as a PWA: click the install icon in the address bar, or menu → **Install App**
+4. The service worker caches the app and walkthrough data for offline use after first load
+
+> **Why Chromium?** Chromium-based browsers (Chrome, Edge, Chromium) have the most complete Gamepad API implementation and support WebHID for low-latency controller input. Firefox supports the basic Gamepad API but lacks WebHID and may gate controller data behind user interaction. For handheld devices where controller navigation is primary, Chromium gives the best experience.
+
+### Device-specific guides
+
+| Device | Guide |
+|---|---|
+| Steam Deck (Bazzite) | [steam-deck-setup.md](steam-deck-setup.md) |
+| ROG Ally (Bazzite) | [rog-ally-setup.md](rog-ally-setup.md) |
+| Windows PC | [windows-setup.md](windows-setup.md) |
 
 ---
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -4,13 +4,20 @@ This guide covers setting up devices that connect to your walkthrough server —
 
 ## How client mode works
 
-A client fetches walkthroughs from the remote server and caches them locally for offline use. Progress is stored in a local SQLite database and synced bi-directionally with the server:
+A client connects to your walkthrough server, lets you browse the full walkthrough catalog, and **check out** the walkthroughs you want to use on this device. Here's the typical flow:
 
-- Fetches the walkthrough list and checked-out content from the server on a configurable interval (default: every 10 minutes)
-- Caches walkthrough data to disk so the app works fully offline
-- Pushes local progress changes upstream (default: every 30 seconds)
-- Pulls latest progress from the server on startup
-- Only syncs walkthroughs that are "checked out" on the device
+1. **Browse & check out** — Connect to the server and check out the walkthroughs you need. Content is downloaded and cached locally for offline use.
+2. **Play offline** — Use your walkthroughs without internet. Progress saves locally.
+3. **Sync when online** — When the device reconnects, progress automatically syncs to the server. Any progress made on other devices is pulled down too.
+4. **Check in when done** — When you're finished with a walkthrough, check it in. This stops the client from syncing progress for that walkthrough, reducing network traffic.
+
+Under the hood:
+
+- Fetches the walkthrough catalog from the server on a configurable interval (default: every 10 minutes)
+- Only downloads full content for checked-out walkthroughs (the rest are browsable metadata)
+- Caches checked-out walkthrough data to disk so the app works fully offline
+- Pushes local progress changes upstream (default: every 30 seconds) — only for checked-out walkthroughs
+- Pulls latest progress from the server on startup for checked-out walkthroughs
 
 ---
 

--- a/docs/rog-ally-setup.md
+++ b/docs/rog-ally-setup.md
@@ -1,12 +1,13 @@
 # ROG Ally Setup (Bazzite)
 
 ## Prerequisites
-- Same as Steam Deck — server deployed, URL ready
+- Same as Steam Deck — server deployed ([server setup](server-setup.md)), URL ready
+- For local client server setup, see [client setup](client-setup.md#on-a-handheld-running-bazzite-steam-deck--rog-ally)
 
 ## First-time setup (Desktop Mode)
 
 1. Switch to **Desktop Mode**
-2. Open **Firefox** or **Chromium**  
+2. Open **Chromium** (recommended for best controller support) or Chrome
 3. Navigate to your server URL and let the page fully load (caches for offline)
 4. Optional: install as PWA via the browser menu
 
@@ -15,7 +16,7 @@
 Same steps as Steam Deck:
 
 1. Open Steam in Desktop Mode
-2. **Games → Add a Non-Steam Game → Browse** → find your browser
+2. **Games → Add a Non-Steam Game → Browse** → find Chromium
 3. Set Launch Options:
    ```
    --new-window --app=https://walkthroughs.yourdomain.com

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -43,7 +43,7 @@ The server polls the GitHub repo for walkthrough JSON files and serves them to c
 | Component | Role |
 |---|---|
 | **ArgoCD** | GitOps — watches `server/k8s/` on `main` and applies changes automatically |
-| **Argo Rollouts** | Replaces standard Deployments; `Recreate` strategy used (required for RWO PVC) |
+| **Argo Rollouts** | Replaces standard Deployments; canary strategy with maxSurge=0 for recreate behavior (required for RWO PVC) |
 | **Cilium Gateway API** | Ingress via `HTTPRoute` — no nginx ingress needed |
 | **Rook Ceph** | Block storage for the SQLite PVC (`storageClassName: rook-ceph-block`) |
 
@@ -61,13 +61,13 @@ ArgoCD will create the `walkthroughs` namespace, apply all manifests in `server/
 
 ### How CI/CD works
 
-On every push to `main` the workflow (`.github/workflows/deploy.yml`):
+On pushes to `main` that touch `server/**`, `webapp/**`, or the workflow file itself (excluding `server/k8s/**` and `server/argocd/**`), the workflow (`.github/workflows/deploy.yml`):
 1. Builds the multi-stage Docker image (SvelteKit webapp + Go server)
 2. Pushes the image to `ghcr.io/camcast3/walkthrough-server` (tagged with commit SHA)
 3. Updates the image tag in `server/k8s/rollout.yaml`
 4. Commits that change back to `main` with `[skip ci]`
 
-ArgoCD detects the new commit and syncs — triggering a Rollout with `Recreate` strategy.
+ArgoCD detects the new commit and syncs — triggering a Rollout (canary with maxSurge=0, which gives recreate behavior for the RWO PVC).
 
 > **No `KUBECONFIG` secret required.** ArgoCD handles all cluster operations. Walkthroughs are fetched at runtime from GitHub (no ConfigMaps).
 

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -87,7 +87,7 @@ ArgoCD detects the new commit and syncs — triggering a Rollout (canary with ma
 
 ```bash
 # Build the webapp first (the compose file mounts ./webapp/build)
-cd webapp && npm ci && npm run build && cd ..
+cd webapp && npm ci --legacy-peer-deps && npm run build && cd ..
 
 docker compose up
 ```

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -109,7 +109,7 @@ Requires **Go 1.26+** and **Node 22+**.
 
 ```bash
 # Build the webapp
-cd webapp && npm ci && npm run build && cd ..
+cd webapp && npm ci --legacy-peer-deps && npm run build && cd ..
 
 # Run in server mode
 cd server

--- a/docs/server-setup.md
+++ b/docs/server-setup.md
@@ -1,0 +1,157 @@
+# Server Setup
+
+This guide covers deploying the walkthrough server — the authoritative hub that stores walkthroughs and syncs progress across devices.
+
+## How server mode works
+
+The server polls the GitHub repo for walkthrough JSON files and serves them to clients (browsers and local client instances). It is the single source of truth for walkthrough content and progress data.
+
+- Polls the GitHub Trees API on a configurable interval (default: every 5 minutes)
+- Stores all progress in a local SQLite database
+- Serves the PWA webapp to browsers
+- Exposes management APIs under `/api/server/` (ingest jobs, connected devices)
+
+## Environment variables
+
+### Server-mode variables
+
+| Variable | Example | Description |
+|---|---|---|
+| `APP_MODE` | `server` | **Required.** Enables server mode |
+| `GITHUB_REPO` | `camcast3/walkthrough-app` | **Required.** GitHub repo in `owner/repo` format |
+| `GITHUB_BRANCH` | `main` | Branch to poll (default: `main`) |
+| `GITHUB_PATH` | `walkthroughs` | Path within the repo (default: `walkthroughs`) |
+| `GITHUB_TOKEN` | *(optional)* | Required for private repos |
+| `GITHUB_REFRESH_INTERVAL` | `5m` | How often to check GitHub for new walkthroughs (default: `5m`) |
+| `GITHUB_CACHE_DIR` | `/data` | Local directory for caching walkthrough data fetched from GitHub |
+
+### Common variables (all modes)
+
+| Variable | Flag | Default | Description |
+|---|---|---|---|
+| `DB_PATH` | `--db` | `/data/progress.sqlite` | Path to SQLite database file |
+| `STATIC_DIR` | `--static` | `/static` | Path to built webapp static files |
+| `LISTEN_ADDR` | `--addr` | `:8080` | Listen address |
+| `WALKTHROUGHS_DIR` | `--walkthroughs` | `/walkthroughs` | Local walkthrough directory (file mode only) |
+
+---
+
+## Option 1: Kubernetes (recommended for always-on)
+
+### Cluster prerequisites
+
+| Component | Role |
+|---|---|
+| **ArgoCD** | GitOps — watches `server/k8s/` on `main` and applies changes automatically |
+| **Argo Rollouts** | Replaces standard Deployments; `Recreate` strategy used (required for RWO PVC) |
+| **Cilium Gateway API** | Ingress via `HTTPRoute` — no nginx ingress needed |
+| **Rook Ceph** | Block storage for the SQLite PVC (`storageClassName: rook-ceph-block`) |
+
+### One-time setup
+
+**1. Register with ArgoCD** (run once from any machine with cluster access):
+```bash
+kubectl apply -f server/argocd/app.yaml -n argocd
+```
+
+ArgoCD will create the `walkthroughs` namespace, apply all manifests in `server/k8s/`, and watch this repo for changes going forward.
+
+**2. Allow GitHub Actions to push commits back** (needed for manifest updates):
+- Repo **Settings → Actions → General → Workflow permissions → Read and write permissions**
+
+### How CI/CD works
+
+On every push to `main` the workflow (`.github/workflows/deploy.yml`):
+1. Builds the multi-stage Docker image (SvelteKit webapp + Go server)
+2. Pushes the image to `ghcr.io/camcast3/walkthrough-server` (tagged with commit SHA)
+3. Updates the image tag in `server/k8s/rollout.yaml`
+4. Commits that change back to `main` with `[skip ci]`
+
+ArgoCD detects the new commit and syncs — triggering a Rollout with `Recreate` strategy.
+
+> **No `KUBECONFIG` secret required.** ArgoCD handles all cluster operations. Walkthroughs are fetched at runtime from GitHub (no ConfigMaps).
+
+### Kubernetes manifests
+
+| File | Kind | Purpose |
+|---|---|---|
+| `server/k8s/rollout.yaml` | `argoproj.io/v1alpha1/Rollout` | App workload; canary with maxSurge=0 for RWO PVC |
+| `server/k8s/service.yaml` | `Service` | ClusterIP on port 80 → container 8080 |
+| `server/k8s/httproute.yaml` | `gateway.networking.k8s.io/v1/HTTPRoute` | Cilium Gateway API routing |
+| `server/k8s/pvc.yaml` | `PersistentVolumeClaim` | 1 Gi `rook-ceph-block` volume for SQLite + cache |
+| `server/argocd/app.yaml` | `argoproj.io/v1alpha1/Application` | ArgoCD app definition (add to app-of-apps) |
+
+---
+
+## Option 2: Docker Compose
+
+```bash
+# Build the webapp first (the compose file mounts ./webapp/build)
+cd webapp && npm ci && npm run build && cd ..
+
+docker compose up
+```
+
+The server is available at `http://localhost:8080`. The default `docker-compose.yml` runs in **client mode** — to run as a server, update the environment in `docker-compose.yml`:
+
+```yaml
+environment:
+  APP_MODE: server
+  GITHUB_REPO: camcast3/walkthrough-app
+  # ...
+```
+
+---
+
+## Option 3: Run directly (no Docker)
+
+Requires **Go 1.26+** and **Node 22+**.
+
+```bash
+# Build the webapp
+cd webapp && npm ci && npm run build && cd ..
+
+# Run in server mode
+cd server
+APP_MODE=server \
+GITHUB_REPO=camcast3/walkthrough-app \
+DB_PATH=../data/progress.sqlite \
+STATIC_DIR=../webapp/build \
+go run . --addr :8080
+```
+
+For development (file mode — reads from local `walkthroughs/` directory):
+
+```bash
+cd server
+go run . \
+  --addr :8080 \
+  --db ../data/progress.sqlite \
+  --walkthroughs ../walkthroughs \
+  --static ../webapp/build
+```
+
+Open `http://localhost:8080`.
+
+---
+
+## Updating walkthroughs
+
+Push JSON files to `walkthroughs/<game>/` in this repo. The server polls the GitHub Trees API and picks up changes automatically — no image rebuild or redeployment needed.
+
+## API routes
+
+| Endpoint | Method | Description | Mode |
+|---|---|---|---|
+| `/api/config` | GET | App configuration (mode, features) | All |
+| `/api/walkthroughs` | GET | List all walkthrough metadata | All |
+| `/api/walkthroughs/{id}` | GET | Get full walkthrough content | All |
+| `/api/progress/{id}` | GET | Get progress for a walkthrough | All |
+| `/api/progress/{id}` | PUT | Save progress for a walkthrough | All |
+| `/api/checkouts` | GET | List checked-out walkthroughs | All |
+| `/api/checkouts/{id}` | PUT | Check out a walkthrough | All |
+| `/api/checkouts/{id}` | DELETE | Remove a checkout | All |
+| `/api/server/ingest` | POST | Start a walkthrough ingest job | Server only |
+| `/api/server/ingest` | GET | List ingest jobs | Server only |
+| `/api/server/ingest/{id}` | GET | Get ingest job status | Server only |
+| `/api/server/devices` | GET | List connected devices | Server only |

--- a/docs/steam-deck-setup.md
+++ b/docs/steam-deck-setup.md
@@ -1,13 +1,14 @@
 # Steam Deck Setup (Bazzite)
 
 ## Prerequisites
-- Your walkthrough server is deployed and accessible (see [Kubernetes setup](../README.md#deploying-to-kubernetes))
+- Your walkthrough server is deployed and accessible (see [server setup](server-setup.md))
 - You have the server URL (e.g. `https://walkthroughs.yourdomain.com` or a LAN IP like `http://192.168.1.x:8080`)
+- For local client server setup, see [client setup](client-setup.md#on-a-handheld-running-bazzite-steam-deck--rog-ally)
 
 ## First-time setup (Desktop Mode)
 
 1. Open **Desktop Mode** (hold Power → Switch to Desktop)
-2. Open **Firefox** or **Chromium**
+2. Open **Chromium** (recommended for best controller support) or Chrome
 3. Navigate to your server URL
 4. Wait for the page to fully load (this caches the app for offline use)
 5. Optional: click the browser menu → **Install App** or **Add to Home Screen** to install it as a PWA
@@ -16,7 +17,7 @@
 
 1. In Desktop Mode, open **Steam**
 2. Click **Games → Add a Non-Steam Game**
-3. Click **Browse** and find your browser (e.g. `/usr/bin/chromium-browser` or `flatpak run org.mozilla.firefox`)
+3. Click **Browse** and find Chromium (e.g. `/usr/bin/chromium-browser` or `flatpak run com.github.nickvergessen.chromium`)
 4. Add it, then go to its **Properties**
 5. Set **Launch Options** to:
    ```

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -24,10 +24,10 @@ If you want to run the sync server locally on Windows for development:
 cd server
 go build -o walkthrough-server.exe .
 .\walkthrough-server.exe `
-  -db C:\walkthrough-data\progress.sqlite `
-  -walkthroughs ..\walkthroughs `
-  -static ..\webapp\build `
-  -addr :8080
+  --db C:\walkthrough-data\progress.sqlite `
+  --walkthroughs ..\walkthroughs `
+  --static ..\webapp\build `
+  --addr :8080
 ```
 
 To auto-start on login, create a Task Scheduler task:

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -1,7 +1,7 @@
 # Windows PC Setup
 
 ## Prerequisites
-- Server is deployed to your k8s cluster and accessible from your PC
+- Server is deployed and accessible (see [server setup](server-setup.md))
 - You have the server URL
 
 ## Install as PWA (recommended)

--- a/server/README.md
+++ b/server/README.md
@@ -39,7 +39,7 @@ go build -o walkthrough-server.exe .
 
 ## Operating modes
 
-The server supports three modes via the `APP_MODE` environment variable. See the [root README](../README.md#architecture-server-mode-vs-client-mode) for full details.
+The server supports three modes via the `APP_MODE` environment variable. See [docs/server-setup.md](../docs/server-setup.md) and [docs/client-setup.md](../docs/client-setup.md) for full details.
 
 | Mode | `APP_MODE` | Description |
 |---|---|---|
@@ -80,4 +80,4 @@ docker run -p 8080:8080 \
 
 ## Environment variables
 
-See the [root README](../README.md#architecture-server-mode-vs-client-mode) for the full environment variable reference.
+See [docs/server-setup.md](../docs/server-setup.md) for the full environment variable reference.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,83 @@
+# Walkthrough App — Server
+
+Go HTTP server that serves the walkthrough PWA, manages progress data in SQLite, and synchronizes walkthroughs from GitHub or a remote server instance.
+
+## Prerequisites
+
+- **Go 1.26+** (see `go.mod`)
+- No CGO required — uses pure-Go SQLite (`modernc.org/sqlite`)
+
+## Quick start
+
+```bash
+# Build
+go build -o walkthrough-server .
+
+# Run in file mode (development — reads walkthroughs from local directory)
+./walkthrough-server \
+  --addr :8080 \
+  --db ../data/progress.sqlite \
+  --walkthroughs ../walkthroughs \
+  --static ../webapp/build
+```
+
+## Build & test
+
+```bash
+# Build
+go build ./...
+
+# Run tests
+go test ./...
+
+# Build binary (Linux — for Docker/k8s)
+GOOS=linux GOARCH=amd64 go build -o walkthrough-server .
+
+# Build binary (Windows)
+go build -o walkthrough-server.exe .
+```
+
+## Operating modes
+
+The server supports three modes via the `APP_MODE` environment variable. See the [root README](../README.md#architecture-server-mode-vs-client-mode) for full details.
+
+| Mode | `APP_MODE` | Description |
+|---|---|---|
+| **Server** | `server` | Polls GitHub for walkthroughs, serves as authoritative source |
+| **Client** | `client` | Fetches from a remote server, syncs progress upstream |
+| **File** | *(unset)* | Reads walkthroughs from local filesystem |
+
+## Project structure
+
+```
+main.go              Entry point, routing, mode selection
+handlers/
+├── handlers.go      HTTP handler implementations (CRUD, config, checkouts)
+└── ingest.go        Walkthrough ingestion pipeline (server mode only)
+source/              Walkthrough data sources (GitHub, remote, file)
+store/               SQLite database layer (progress, checkouts, local walkthroughs)
+upstream/            Progress sync client (client mode → server)
+k8s/                 Kubernetes manifests
+argocd/              ArgoCD application manifest
+Dockerfile           Multi-stage build (webapp + server)
+```
+
+## Docker
+
+The `Dockerfile` is a multi-stage build that compiles both the SvelteKit webapp and the Go server:
+
+```bash
+# Build from repo root
+docker build -f server/Dockerfile -t walkthrough-server .
+
+# Run
+docker run -p 8080:8080 \
+  -e APP_MODE=server \
+  -e GITHUB_REPO=camcast3/walkthrough-app \
+  -v walkthrough-data:/data \
+  walkthrough-server
+```
+
+## Environment variables
+
+See the [root README](../README.md#architecture-server-mode-vs-client-mode) for the full environment variable reference.

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,42 +1,71 @@
-# sv
+# Walkthrough App — Webapp
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+SvelteKit PWA frontend for the walkthrough checklist app. Built with **Svelte 5** (runes mode), **TypeScript 6**, and **Vite 8**. Outputs a fully static site via `adapter-static` that is served by the Go backend.
 
-## Creating a project
+## Prerequisites
 
-If you're seeing this, you've probably already done this step. Congrats!
+- **Node.js 22+** (matches the Dockerfile build stage)
+- npm (included with Node.js)
 
-```sh
-# create a new project
-npx sv create my-app
-```
+## Quick start
 
-To recreate this project with the same configuration:
+```bash
+# Install dependencies
+npm install --legacy-peer-deps
 
-```sh
-# recreate this project
-npx sv@0.15.2 create --template minimal --types ts --no-install .
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
-
-```sh
+# Start dev server (hot-reload at http://localhost:5173)
 npm run dev
 
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
-```
+# Type-check
+npm run check
 
-## Building
-
-To create a production version of your app:
-
-```sh
+# Production build (outputs to ./build)
 npm run build
 ```
 
-You can preview the production build with `npm run preview`.
+## Scripts
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+| Command | Description |
+|---|---|
+| `npm run dev` | Start Vite dev server with HMR |
+| `npm run build` | Production build → `./build/` |
+| `npm run preview` | Preview the production build locally |
+| `npm run check` | `svelte-kit sync` + `svelte-check` (type checking) |
+| `npm run check:watch` | Same as `check` but in watch mode |
+
+## Architecture
+
+The webapp is a single-page app with a service worker for offline support. It communicates with the Go server via REST APIs (`/api/*`).
+
+```
+src/
+├── lib/           Shared state, types, utilities
+│   ├── state.ts   Global app state (runes-based)
+│   └── types.ts   TypeScript type definitions
+├── routes/        SvelteKit pages and layouts
+└── app.html       HTML shell
+```
+
+### Key features
+
+- **PWA with offline support** — service worker caches the app and walkthrough data
+- **Gamepad navigation** — full controller support (D-pad, A/B buttons, LB/RB)
+- **Power-save mode** — automatically reduces GPU effects on handheld devices
+- **Responsive design** — optimized for touch, controller, and mouse input
+- **Markdown rendering** — full prose walkthroughs with embedded milestone checkpoints
+
+### Build output
+
+`npm run build` produces a static site in `./build/` using `adapter-static` with `fallback: 'index.html'` for SPA routing. The Go server serves these files and handles the `/api/*` routes.
+
+## Dependencies
+
+### Runtime
+- **[marked](https://github.com/markedjs/marked)** — Markdown → HTML rendering
+- **[idb-keyval](https://github.com/nicedoc/idb-keyval)** — IndexedDB key-value store for offline data
+
+### Dev
+- **SvelteKit 2** / **Svelte 5** — component framework (runes mode)
+- **TypeScript 6** — type checking
+- **Vite 8** — build tool
+- **vite-plugin-pwa** — service worker generation

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -10,8 +10,8 @@ SvelteKit PWA frontend for the walkthrough checklist app. Built with **Svelte 5*
 ## Quick start
 
 ```bash
-# Install dependencies
-npm install --legacy-peer-deps
+# Install dependencies (matches the Dockerfile build stage)
+npm ci --legacy-peer-deps
 
 # Start dev server (hot-reload at http://localhost:5173)
 npm run dev

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -39,11 +39,15 @@ The webapp is a single-page app with a service worker for offline support. It co
 
 ```
 src/
-├── lib/           Shared state, types, utilities
-│   ├── state.ts   Global app state (runes-based)
-│   └── types.ts   TypeScript type definitions
-├── routes/        SvelteKit pages and layouts
-└── app.html       HTML shell
+├── lib/             Shared state, types, utilities
+│   ├── assets/      Static assets (icons, images)
+│   ├── gamepad.ts   Gamepad API integration
+│   ├── index.ts     Barrel exports
+│   ├── state.ts     Global app state (runes-based)
+│   ├── sync.ts      Offline sync / service worker logic
+│   └── types.ts     TypeScript type definitions
+├── routes/          SvelteKit pages and layouts
+└── app.html         HTML shell
 ```
 
 ### Key features
@@ -62,7 +66,7 @@ src/
 
 ### Runtime
 - **[marked](https://github.com/markedjs/marked)** — Markdown → HTML rendering
-- **[idb-keyval](https://github.com/nicedoc/idb-keyval)** — IndexedDB key-value store for offline data
+- **[idb-keyval](https://github.com/jakearchibald/idb-keyval)** — IndexedDB key-value store for offline data
 
 ### Dev
 - **SvelteKit 2** / **Svelte 5** — component framework (runes mode)


### PR DESCRIPTION
Updates all README files to represent the latest state of the project.

## Changes

### Root README.md
- **Fixed version requirements**: Go 1.26+ and Node 22+ (was Go 1.21+ and Node 18+), matching \go.mod\ and the Dockerfile
- **Added server vs client architecture section**: comprehensive docs explaining the three operating modes (server, client, file) with env var tables
- **Restructured into clear sections**: 'Setting up the server' (K8s, Docker Compose, direct) and 'Setting up clients' (browser-only, local client server)
- **Added Bazzite handheld setup**: podman container instructions with systemd auto-start for Steam Deck / ROG Ally
- **Documented all API routes** with method, path, description, and mode availability

### webapp/README.md
- Replaced default SvelteKit boilerplate with project-specific documentation
- Documents prerequisites (Node 22+), all npm scripts, architecture overview, key features, and dependency listing

### server/README.md (new)
- Documents Go server prerequisites (Go 1.26+), build/test commands, operating modes, project structure, Docker usage, and environment variables

Closes #12