### PR TITLE
ci: simplify deploy workflow to build + release only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,4 +108,4 @@ jobs:
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
             --generate-notes \
-            --target main
+            --target "${{ github.sha }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build and Update Manifests
+name: Build and Release
 
 on:
   push:
@@ -52,17 +52,16 @@ jobs:
       - run: npm run check
       - run: npm run test
 
-  build-and-update:
+  build-and-release:
     needs: [server-tests, webapp-tests]
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # needed to commit manifest updates back to main
+      contents: write   # needed to create GitHub releases
       packages: write   # needed to push to ghcr.io
 
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       # ── Determine next version ─────────────────────────────────────────
@@ -83,8 +82,6 @@ jobs:
           echo "Next version: $NEXT (previous: $LATEST)"
 
       # ── Build + push Docker image ─────────────────────────────────────────
-      # The multi-stage Dockerfile builds the webapp, Go server, and bakes in
-      # walkthroughs — no ConfigMap needed.
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -102,22 +99,6 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-
-      # ── Update manifests — ArgoCD detects the commit and syncs ───────────
-      - name: Update image tag in Rollout manifest
-        run: |
-          sed -i "s|image: ghcr.io/.*/walkthrough-server:.*|image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}|" \
-            server/k8s/rollout.yaml
-
-      - name: Commit updated manifests
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add server/k8s/rollout.yaml
-          git diff --cached --quiet || \
-            git commit -m "ci: update image to ${GITHUB_SHA::8} [skip ci]"
-          git pull --rebase origin main
-          git push
 
       # ── Create GitHub release ────────────────────────────────────────────
       - name: Create release


### PR DESCRIPTION
Strips deploy.yml down to just: test -> build Docker image -> push to GHCR -> create GitHub release.

Removed:
- sed step that updated image tag in rollout.yaml
- git commit + push step that committed manifests back to main

Kept:
- Path-filtered triggers (server/**, webapp/**, workflow file)
- Go server tests + Webapp unit tests as gates
- Docker build+push (tagged: latest, vX.Y.Z, commit SHA)
- GitHub release creation with auto-generated notes

Renamed workflow: Build and Update Manifests -> Build and Release