### PR TITLE
feat: add kustomization.yaml for Argo CD Image Updater support

### DIFF
--- a/server/k8s/kustomization.yaml
+++ b/server/k8s/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rollout.yaml
+  - service.yaml
+  - httproute.yaml
+
+images:
+  - name: ghcr.io/camcast3/walkthrough-server
+    newTag: f07efbcae9804dab65c6123fa19d37e71ad1f6a4

--- a/server/k8s/rollout.yaml
+++ b/server/k8s/rollout.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: ghcr.io/camcast3/walkthrough-server:f07efbcae9804dab65c6123fa19d37e71ad1f6a4
+          image: ghcr.io/camcast3/walkthrough-server
           ports:
             - containerPort: 8080
           env:


### PR DESCRIPTION
Move image tag management from hardcoded in rollout.yaml to kustomization.yaml images transformer. This allows Argo CD Image Updater to override the tag via kustomize parameter overrides.

## Changes
- **server/k8s/kustomization.yaml** — new Kustomize config listing resources and managing image tags
- **server/k8s/rollout.yaml** — remove hardcoded tag (now managed by kustomization.yaml)

## Why
Argo CD Image Updater (v1.1.x CRD-based) only supports Helm and Kustomize source types. Adding a kustomization.yaml converts the ArgoCD Application from Directory to Kustomize, enabling automatic image tag updates.