### PR TITLE
fix: remove unused Image Updater annotations from Application

### DIFF
--- a/server/argocd/app.yaml
+++ b/server/argocd/app.yaml
@@ -9,12 +9,6 @@ kind: Application
 metadata:
   name: walkthrough-app
   namespace: argocd
-  annotations:
-    argocd-image-updater.argoproj.io/image-list: server=ghcr.io/camcast3/walkthrough-server
-    argocd-image-updater.argoproj.io/server.update-strategy: semver
-    argocd-image-updater.argoproj.io/server.kustomize.image-name: ghcr.io/camcast3/walkthrough-server
-    argocd-image-updater.argoproj.io/write-back-method: git
-    argocd-image-updater.argoproj.io/git-branch: main
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
The Argo CD Image Updater on this cluster uses an \ImageUpdater\ CRD with \rgocd\ write-back (parameter overrides), not annotation-based configuration. The annotations added in #31 were being ignored.

Removes the unused annotations to avoid confusion.