### PR TITLE
Intake PR 2 — Section & checkpoint detection

### DIFF
--- a/tools/intake/src/converter/detect-checkpoints.ts
+++ b/tools/intake/src/converter/detect-checkpoints.ts
@@ -1,0 +1,27 @@
+/**
+ * Auto-generates checkpoints at H3 headings within a section.
+ * These serve as "resume from here" markers.
+ */
+
+import { MarkdownToken } from './markdown-parser.js';
+import { WalkthroughCheckpoint } from '../types.js';
+import slugify from 'slugify';
+
+export function detectCheckpoints(
+  tokens: MarkdownToken[],
+  sectionId: string,
+): WalkthroughCheckpoint[] {
+  const checkpoints: WalkthroughCheckpoint[] = [];
+
+  for (const token of tokens) {
+    if (token.type === 'heading' && token.level === 3) {
+      const cpId = `${sectionId}-${slugify(token.content, { lower: true, strict: true })}`;
+      checkpoints.push({
+        id: cpId,
+        label: token.content,
+      });
+    }
+  }
+
+  return checkpoints;
+}

--- a/tools/intake/src/converter/detect-sections.ts
+++ b/tools/intake/src/converter/detect-sections.ts
@@ -1,0 +1,47 @@
+/**
+ * Splits parsed markdown tokens into walkthrough sections.
+ * H2 headings (##) mark section boundaries.
+ */
+
+import { MarkdownToken } from './markdown-parser.js';
+import slugify from 'slugify';
+
+export interface RawSection {
+  id: string;
+  title: string;
+  tokens: MarkdownToken[];
+}
+
+export function detectSections(tokens: MarkdownToken[]): RawSection[] {
+  const sections: RawSection[] = [];
+  let currentTitle = 'Introduction';
+  let currentTokens: MarkdownToken[] = [];
+
+  for (const token of tokens) {
+    if (token.type === 'heading' && token.level === 2) {
+      // Save previous section if it has content
+      if (currentTokens.length > 0) {
+        sections.push({
+          id: slugify(currentTitle, { lower: true, strict: true }),
+          title: currentTitle,
+          tokens: currentTokens,
+        });
+      }
+      currentTitle = token.content;
+      currentTokens = [];
+    } else {
+      currentTokens.push(token);
+    }
+  }
+
+  // Don't forget the last section
+  if (currentTokens.length > 0) {
+    sections.push({
+      id: slugify(currentTitle, { lower: true, strict: true }),
+      title: currentTitle,
+      tokens: currentTokens,
+    });
+  }
+
+  return sections;
+}

--- a/tools/intake/tests/converter/__snapshots__/detect-sections.test.ts.snap
+++ b/tools/intake/tests/converter/__snapshots__/detect-sections.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`detectSections — Cold Steel II snapshot > produces stable section breakdown for page1.md 1`] = `
+[
+  {
+    "id": "introduction",
+    "title": "Introduction",
+    "tokenCount": 1,
+  },
+]
+`;

--- a/tools/intake/tests/converter/detect-checkpoints.test.ts
+++ b/tools/intake/tests/converter/detect-checkpoints.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { detectCheckpoints } from '../../src/converter/detect-checkpoints.js';
+import { parseMarkdown } from '../../src/converter/markdown-parser.js';
+
+describe('detectCheckpoints', () => {
+  it('generates checkpoints from H3 headings', () => {
+    const tokens = parseMarkdown('### Morning\n\nText\n\n### Afternoon\n\nMore text');
+    const checkpoints = detectCheckpoints(tokens, 'prologue');
+    expect(checkpoints).toHaveLength(2);
+    expect(checkpoints[0]).toMatchObject({ id: 'prologue-morning', label: 'Morning' });
+    expect(checkpoints[1]).toMatchObject({ id: 'prologue-afternoon', label: 'Afternoon' });
+  });
+
+  it('ignores non-H3 headings', () => {
+    const tokens = parseMarkdown('## Section\n\n#### Deep heading\n\nText');
+    const checkpoints = detectCheckpoints(tokens, 'section');
+    expect(checkpoints).toHaveLength(0); // only H2 and H4, no H3
+  });
+
+  it('returns empty array when no H3 headings exist', () => {
+    const tokens = parseMarkdown('Just paragraphs\n\nMore text');
+    const checkpoints = detectCheckpoints(tokens, 'intro');
+    expect(checkpoints).toHaveLength(0);
+  });
+
+  it('slugifies checkpoint IDs correctly', () => {
+    const tokens = parseMarkdown('### Act 1 — Part 2\n\nText');
+    const checkpoints = detectCheckpoints(tokens, 'main');
+    expect(checkpoints[0].id).toMatch(/^main-/);
+  });
+});

--- a/tools/intake/tests/converter/detect-sections.test.ts
+++ b/tools/intake/tests/converter/detect-sections.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import { detectSections } from '../../src/converter/detect-sections.js';
+import { parseMarkdown } from '../../src/converter/markdown-parser.js';
+
+describe('detectSections', () => {
+  it('splits on H2 headings', () => {
+    const tokens = parseMarkdown('## Prologue\n\nText here\n\n## Act 1\n\nMore text');
+    const sections = detectSections(tokens);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].title).toBe('Prologue');
+    expect(sections[1].title).toBe('Act 1');
+  });
+
+  it('creates Introduction section for content before first H2', () => {
+    const tokens = parseMarkdown('Some intro text\n\n## First Section\n\nContent');
+    const sections = detectSections(tokens);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].title).toBe('Introduction');
+    expect(sections[1].title).toBe('First Section');
+  });
+
+  it('generates slugified IDs', () => {
+    const tokens = parseMarkdown('## Act 1 - Part 2\n\nText');
+    const sections = detectSections(tokens);
+    expect(sections[0].id).toBe('act-1-part-2');
+  });
+
+  it('handles document with no H2 headings as single section', () => {
+    const tokens = parseMarkdown('### Sub heading\n\nJust paragraphs\n\nMore text');
+    const sections = detectSections(tokens);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].title).toBe('Introduction');
+  });
+
+  it('preserves tokens within sections', () => {
+    const tokens = parseMarkdown('## Section\n\nPara 1\n\n| A |\n|---|\n| B |');
+    const sections = detectSections(tokens);
+    expect(sections[0].tokens).toHaveLength(2); // paragraph + table
+  });
+});
+
+describe('detectSections — Cold Steel II snapshot', () => {
+  it('produces stable section breakdown for page1.md', () => {
+    const dirname = path.dirname(fileURLToPath(import.meta.url));
+    const fixturePath = path.join(
+      dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      'walkthroughs',
+      'trails-of-cold-steel-ii',
+      'page1.md',
+    );
+    const md = readFileSync(fixturePath, 'utf-8');
+    const sections = detectSections(parseMarkdown(md));
+    const summary = sections.map(s => ({ id: s.id, title: s.title, tokenCount: s.tokens.length }));
+    expect(summary).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary

Adds section and checkpoint detection to the intake converter pipeline (PR 2 of the Walkthrough Intake System).

## Files added

| File | Purpose |
|------|---------|
| tools/intake/src/converter/detect-sections.ts | Splits parsed markdown tokens into RawSection[] on H2 boundaries |
| tools/intake/src/converter/detect-checkpoints.ts | Extracts WalkthroughCheckpoint[] from H3 headings within a section |
| tools/intake/tests/converter/detect-sections.test.ts | Unit tests + snapshot test against Cold Steel II fixture |
| tools/intake/tests/converter/detect-checkpoints.test.ts | Unit tests for checkpoint extraction |
| tools/intake/tests/converter/__snapshots__/detect-sections.test.ts.snap | Vitest snapshot for stable section breakdown |

## Verification

- npx tsc --noEmit passes
- npm test: 23 tests pass (13 from PR 1 markdown-parser + 6 detect-sections + 4 detect-checkpoints)
- Snapshot test reads walkthroughs/trails-of-cold-steel-ii/page1.md via fs.readFileSync

## Snapshot fixture

The snapshot test uses walkthroughs/trails-of-cold-steel-ii/page1.md as a real-world fixture.