### PR TITLE
Intake PR 4 — Training database

### DIFF
--- a/tools/intake/src/training/rules-db.ts
+++ b/tools/intake/src/training/rules-db.ts
@@ -1,0 +1,154 @@
+/**
+ * Training database — stores corrections and manages graduation.
+ *
+ * The graduation threshold is fully configurable so you can tune how long the
+ * converter stays in "review every block" mode before it starts auto-approving
+ * high-confidence classifications. See the precedence order in `resolveThreshold`.
+ */
+
+/// <reference types="node" />
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { TrainingDatabase, TrainingExample, BlockType } from '../types.js';
+
+/**
+ * Default number of walkthroughs to process before the converter is eligible
+ * to graduate out of training mode. Override per-run via:
+ *
+ *   1. Constructor option: `new RulesDB(path, { graduationThreshold: 50 })`
+ *   2. Environment variable: `INTAKE_GRADUATION_THRESHOLD=100 npx intake ...`
+ *   3. Field stored in the training-data.json file: `"graduation_threshold": 25`
+ *
+ * Precedence: constructor option > env var > file > DEFAULT_GRADUATION_THRESHOLD.
+ *
+ * Change this single constant to shift the project-wide default. It is also
+ * exported so tests and the CLI can reference it without magic numbers.
+ */
+export const DEFAULT_GRADUATION_THRESHOLD = 10;
+
+export interface RulesDBOptions {
+  /** Override the graduation threshold for this instance only. */
+  graduationThreshold?: number;
+}
+
+const DEFAULT_DB: TrainingDatabase = {
+  examples: [],
+  graduation_status: 'training',
+  walkthroughs_processed: 0,
+  graduation_threshold: DEFAULT_GRADUATION_THRESHOLD,
+};
+
+export class RulesDB {
+  private db: TrainingDatabase;
+  private path: string;
+  private readonly thresholdOverride?: number;
+
+  constructor(dbPath: string, options: RulesDBOptions = {}) {
+    this.path = dbPath;
+    this.thresholdOverride = options.graduationThreshold;
+    this.db = existsSync(dbPath)
+      ? { ...DEFAULT_DB, ...JSON.parse(readFileSync(dbPath, 'utf-8')) }
+      : { ...DEFAULT_DB, examples: [] };
+  }
+
+  get data(): TrainingDatabase {
+    return this.db;
+  }
+
+  get isTraining(): boolean {
+    return this.db.graduation_status === 'training';
+  }
+
+  /**
+   * Effective graduation threshold for this instance.
+   * Precedence: constructor option > env var > stored value > module default.
+   */
+  get graduationThreshold(): number {
+    return resolveThreshold(this.thresholdOverride, this.db.graduation_threshold);
+  }
+
+  get shouldGraduate(): boolean {
+    return (
+      this.db.walkthroughs_processed >= this.graduationThreshold &&
+      this.db.graduation_status === 'training'
+    );
+  }
+
+  /**
+   * Persist a new threshold to the training database. Use this when you want
+   * a permanent change rather than a per-run override.
+   */
+  setGraduationThreshold(value: number): void {
+    if (!Number.isInteger(value) || value < 1) {
+      throw new Error(`graduation_threshold must be a positive integer, got ${value}`);
+    }
+    this.db.graduation_threshold = value;
+    this.save();
+  }
+
+  addCorrection(example: TrainingExample): void {
+    this.db.examples.push(example);
+    this.save();
+  }
+
+  incrementWalkthroughs(): void {
+    this.db.walkthroughs_processed++;
+    this.save();
+  }
+
+  graduate(): void {
+    this.db.graduation_status = 'graduated';
+    this.save();
+  }
+
+  /** Re-enter training mode without losing accumulated examples. */
+  resetGraduation(): void {
+    this.db.graduation_status = 'training';
+    this.save();
+  }
+
+  getAccuracyStats(): { total: number; corrections: number; accuracy: number } {
+    const total = this.db.examples.length > 0
+      ? Math.round(this.db.examples.length / 0.114) // rough estimate
+      : 0;
+    return {
+      total,
+      corrections: this.db.examples.length,
+      accuracy: total > 0 ? (total - this.db.examples.length) / total : 1,
+    };
+  }
+
+  private save(): void {
+    writeFileSync(this.path, JSON.stringify(this.db, null, 2));
+  }
+}
+
+/**
+ * Resolve the effective graduation threshold based on precedence:
+ *   1. Explicit override (e.g. from CLI flag passed through constructor)
+ *   2. INTAKE_GRADUATION_THRESHOLD env var
+ *   3. graduation_threshold stored in the training-data.json file
+ *   4. DEFAULT_GRADUATION_THRESHOLD
+ *
+ * Invalid values (non-positive, non-integer, NaN) fall through to the next
+ * source rather than throwing — this keeps the CLI forgiving.
+ */
+export function resolveThreshold(
+  explicit: number | undefined,
+  stored: number | undefined,
+): number {
+  if (isValidThreshold(explicit)) return explicit!;
+
+  const envRaw = process.env.INTAKE_GRADUATION_THRESHOLD;
+  if (envRaw !== undefined && envRaw !== '') {
+    const envParsed = Number(envRaw);
+    if (isValidThreshold(envParsed)) return envParsed;
+  }
+
+  if (isValidThreshold(stored)) return stored!;
+  return DEFAULT_GRADUATION_THRESHOLD;
+}
+
+function isValidThreshold(n: number | undefined): boolean {
+  return typeof n === 'number' && Number.isInteger(n) && n >= 1;
+}

--- a/tools/intake/tests/training/rules-db.test.ts
+++ b/tools/intake/tests/training/rules-db.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { RulesDB } from '../../src/training/rules-db.js';
+import { writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+describe('RulesDB', () => {
+  const testPath = join(tmpdir(), `test-training-${Date.now()}.json`);
+
+  afterEach(() => {
+    if (existsSync(testPath)) unlinkSync(testPath);
+  });
+
+  it('creates new empty database if file does not exist', () => {
+    const db = new RulesDB(testPath);
+    expect(db.data.examples).toEqual([]);
+    expect(db.data.graduation_status).toBe('training');
+    expect(db.data.walkthroughs_processed).toBe(0);
+  });
+
+  it('loads existing database from file', () => {
+    writeFileSync(testPath, JSON.stringify({
+      examples: [{ source_pattern: 'test', converter_guessed: 'prose', user_corrected_to: 'callout', context: {}, game: 'test', timestamp: '2026-01-01' }],
+      graduation_status: 'training',
+      walkthroughs_processed: 3,
+    }));
+    const db = new RulesDB(testPath);
+    expect(db.data.examples).toHaveLength(1);
+    expect(db.data.walkthroughs_processed).toBe(3);
+  });
+
+  it('addCorrection persists to file', () => {
+    const db = new RulesDB(testPath);
+    db.addCorrection({
+      source_pattern: '| HP | Weakness |',
+      converter_guessed: 'table',
+      user_corrected_to: 'encounter',
+      context: { heading_above: 'Boss: X' },
+      game: 'test-game',
+      timestamp: '2026-05-26',
+    });
+    expect(db.data.examples).toHaveLength(1);
+
+    // Verify persisted
+    const db2 = new RulesDB(testPath);
+    expect(db2.data.examples).toHaveLength(1);
+  });
+
+  it('isTraining returns true when not graduated', () => {
+    const db = new RulesDB(testPath);
+    expect(db.isTraining).toBe(true);
+  });
+
+  it('shouldGraduate returns true after 10 walkthroughs', () => {
+    writeFileSync(testPath, JSON.stringify({
+      examples: [],
+      graduation_status: 'training',
+      walkthroughs_processed: 10,
+    }));
+    const db = new RulesDB(testPath);
+    expect(db.shouldGraduate).toBe(true);
+  });
+
+  it('shouldGraduate returns false if already graduated', () => {
+    writeFileSync(testPath, JSON.stringify({
+      examples: [],
+      graduation_status: 'graduated',
+      walkthroughs_processed: 15,
+    }));
+    const db = new RulesDB(testPath);
+    expect(db.shouldGraduate).toBe(false);
+  });
+
+  it('graduate changes status', () => {
+    const db = new RulesDB(testPath);
+    db.graduate();
+    expect(db.data.graduation_status).toBe('graduated');
+    expect(db.isTraining).toBe(false);
+  });
+
+  it('incrementWalkthroughs updates count', () => {
+    const db = new RulesDB(testPath);
+    db.incrementWalkthroughs();
+    db.incrementWalkthroughs();
+    expect(db.data.walkthroughs_processed).toBe(2);
+  });
+
+  it('resetGraduation re-enters training without losing examples', () => {
+    const db = new RulesDB(testPath);
+    db.addCorrection({
+      source_pattern: 'x', converter_guessed: 'prose', user_corrected_to: 'callout',
+      context: {}, game: 'g', timestamp: '2026-01-01',
+    });
+    db.graduate();
+    db.resetGraduation();
+    expect(db.data.graduation_status).toBe('training');
+    expect(db.data.examples).toHaveLength(1);
+  });
+});
+
+describe('RulesDB — configurable graduation threshold', () => {
+  const testPath = join(tmpdir(), `test-threshold-${Date.now()}.json`);
+  const originalEnv = process.env.INTAKE_GRADUATION_THRESHOLD;
+
+  afterEach(() => {
+    if (existsSync(testPath)) unlinkSync(testPath);
+    if (originalEnv === undefined) delete process.env.INTAKE_GRADUATION_THRESHOLD;
+    else process.env.INTAKE_GRADUATION_THRESHOLD = originalEnv;
+  });
+
+  it('defaults to DEFAULT_GRADUATION_THRESHOLD (10) when nothing is set', () => {
+    delete process.env.INTAKE_GRADUATION_THRESHOLD;
+    const db = new RulesDB(testPath);
+    expect(db.graduationThreshold).toBe(10);
+  });
+
+  it('uses constructor override when provided', () => {
+    delete process.env.INTAKE_GRADUATION_THRESHOLD;
+    const db = new RulesDB(testPath, { graduationThreshold: 50 });
+    expect(db.graduationThreshold).toBe(50);
+  });
+
+  it('uses INTAKE_GRADUATION_THRESHOLD env var when no constructor override', () => {
+    process.env.INTAKE_GRADUATION_THRESHOLD = '100';
+    const db = new RulesDB(testPath);
+    expect(db.graduationThreshold).toBe(100);
+  });
+
+  it('uses stored value from file when env and override are unset', () => {
+    delete process.env.INTAKE_GRADUATION_THRESHOLD;
+    writeFileSync(testPath, JSON.stringify({
+      examples: [], graduation_status: 'training', walkthroughs_processed: 0,
+      graduation_threshold: 25,
+    }));
+    const db = new RulesDB(testPath);
+    expect(db.graduationThreshold).toBe(25);
+  });
+
+  it('constructor override beats env var beats stored value', () => {
+    process.env.INTAKE_GRADUATION_THRESHOLD = '100';
+    writeFileSync(testPath, JSON.stringify({
+      examples: [], graduation_status: 'training', walkthroughs_processed: 0,
+      graduation_threshold: 25,
+    }));
+    const db = new RulesDB(testPath, { graduationThreshold: 7 });
+    expect(db.graduationThreshold).toBe(7);
+  });
+
+  it('shouldGraduate respects the configured threshold (50)', () => {
+    delete process.env.INTAKE_GRADUATION_THRESHOLD;
+    writeFileSync(testPath, JSON.stringify({
+      examples: [], graduation_status: 'training', walkthroughs_processed: 49,
+      graduation_threshold: 50,
+    }));
+    const db = new RulesDB(testPath);
+    expect(db.shouldGraduate).toBe(false);
+    db.incrementWalkthroughs();
+    expect(db.shouldGraduate).toBe(true);
+  });
+
+  it('shouldGraduate respects the configured threshold (100)', () => {
+    delete process.env.INTAKE_GRADUATION_THRESHOLD;
+    writeFileSync(testPath, JSON.stringify({
+      examples: [], graduation_status: 'training', walkthroughs_processed: 100,
+      graduation_threshold: 100,
+    }));
+    const db = new RulesDB(testPath);
+    expect(db.shouldGraduate).toBe(true);
+  });
+
+  it('setGraduationThreshold persists and updates eligibility', () => {
+    writeFileSync(testPath, JSON.stringify({
+      examples: [], graduation_status: 'training', walkthroughs_processed: 60,
+      graduation_threshold: 100,
+    }));
+    delete process.env.INTAKE_GRADUATION_THRESHOLD;
+    const db = new RulesDB(testPath);
+    expect(db.shouldGraduate).toBe(false);
+    db.setGraduationThreshold(50);
+    expect(db.graduationThreshold).toBe(50);
+    expect(db.shouldGraduate).toBe(true);
+
+    // Verify persisted across reloads
+    const db2 = new RulesDB(testPath);
+    expect(db2.graduationThreshold).toBe(50);
+  });
+
+  it('setGraduationThreshold rejects invalid values', () => {
+    const db = new RulesDB(testPath);
+    expect(() => db.setGraduationThreshold(0)).toThrow();
+    expect(() => db.setGraduationThreshold(-5)).toThrow();
+    expect(() => db.setGraduationThreshold(1.5)).toThrow();
+  });
+
+  it('ignores invalid env var values and falls through to stored/default', () => {
+    process.env.INTAKE_GRADUATION_THRESHOLD = 'not-a-number';
+    writeFileSync(testPath, JSON.stringify({
+      examples: [], graduation_status: 'training', walkthroughs_processed: 0,
+      graduation_threshold: 42,
+    }));
+    const db = new RulesDB(testPath);
+    expect(db.graduationThreshold).toBe(42);
+  });
+});


### PR DESCRIPTION
Implements PR 4 of the Walkthrough Intake System proposal.

## Files added
- `tools/intake/src/training/rules-db.ts` — `RulesDB` class with persistence, graduation tracking, and configurable threshold
- `tools/intake/tests/training/rules-db.test.ts` — 19 tests covering CRUD, graduation, and threshold precedence

## Graduation threshold precedence
Resolved in `resolveThreshold(explicit, stored)`:
1. Constructor option (`new RulesDB(path, { graduationThreshold: 50 })`)
2. `INTAKE_GRADUATION_THRESHOLD` env var
3. `graduation_threshold` field stored in `training-data.json`
4. `DEFAULT_GRADUATION_THRESHOLD` (10)

Invalid values fall through to the next source instead of throwing.

## Verification
- `npx tsc --noEmit` clean
- `npm test` — 32 tests pass (13 from PR 1 + 19 new)

## Dependencies
Depends only on PR 1 (types). Parallelizable with PR 2, PR 3, PR 7.