### PR TITLE
Intake PR 3 — Block detection & converter orchestrator

### DIFF
--- a/tools/intake/src/converter/detect-blocks.ts
+++ b/tools/intake/src/converter/detect-blocks.ts
@@ -1,0 +1,399 @@
+/**
+ * Classifies markdown tokens into walkthrough block types.
+ * Uses rule-based detection with confidence scoring.
+ * NEVER modifies content — only assigns types.
+ */
+
+import { MarkdownToken, parseTable } from './markdown-parser.js';
+import { BlockType, WalkthroughBlock } from '../types.js';
+import { TrainingDatabase } from '../types.js';
+
+interface DetectionContext {
+  heading_above?: string;
+  heading_level?: number;
+  surrounding_types: BlockType[];
+  source_site?: string;
+}
+
+interface DetectionResult {
+  block_type: BlockType;
+  confidence: number;
+}
+
+// ── Encounter detection ─────────────────────────────────────────────────────
+
+const ENCOUNTER_HEADING_PATTERNS = [
+  /boss:\s*/i,
+  /boss fight/i,
+  /mini.?boss/i,
+  /battle:\s*/i,
+  /encounter:\s*/i,
+];
+
+const ENCOUNTER_STAT_COLUMNS = ['hp', 'weakness', 'level', 'exp', 'mira', 'drops'];
+
+function isEncounterTable(headers: string[]): boolean {
+  const lowerHeaders = headers.map(h => h.toLowerCase());
+  return ENCOUNTER_STAT_COLUMNS.some(col => lowerHeaders.includes(col));
+}
+
+// ── Callout detection ───────────────────────────────────────────────────────
+
+const CALLOUT_PATTERNS = [
+  /^(warning|caution|danger|important|note|tip)[\s:!]/i,
+  /^⚠/,
+  /^\*\*(warning|note|important|caution|tip)\*\*/i,
+];
+
+// ── Quest detection ─────────────────────────────────────────────────────────
+
+const QUEST_PATTERNS = [
+  /quest:\s*/i,
+  /side quest/i,
+  /hidden quest/i,
+  /main quest/i,
+  /missable quest/i,
+];
+
+// ── Event detection (bonding, missable conversations, time-limited cutscenes) ─
+
+const EVENT_HEADING_PATTERNS = [
+  /^bonding event/i,
+  /^bond event/i,
+  /^free time/i,
+  /^optional event/i,
+  /^missable event/i,
+  /^conversation:/i,
+];
+
+const EVENT_BODY_PATTERNS = [
+  /bonding event/i,
+  /missable (?:conversation|event|cutscene)/i,
+  /one-?time (?:conversation|event|cutscene)/i,
+  /only available (?:during|on|in)/i,
+  /will be lost if/i,
+  /permanently miss(?:able|ed)?/i,
+];
+
+const MISSABLE_KEYWORDS = /\b(missable|missed|permanently lost|permanently miss|one[- ]?time|only available|expires?|locked out)\b/i;
+
+// ── Checklist detection ─────────────────────────────────────────────────────
+
+const CHECKLIST_ITEM_PATTERNS = [
+  /^\s*[-*]\s+.*\(.*location.*\)/i,
+  /^\s*[-*]\s+\[[ x]\]/i,
+  /^\s*\d+\.\s+.*—\s+/,
+];
+
+function looksLikeChecklist(content: string): boolean {
+  const lines = content.split('\n');
+  const matchCount = lines.filter(line =>
+    CHECKLIST_ITEM_PATTERNS.some(p => p.test(line))
+  ).length;
+  return matchCount >= 3 || (matchCount / lines.length) > 0.5;
+}
+
+// ── Main detection ──────────────────────────────────────────────────────────
+
+export function detectBlockType(
+  token: MarkdownToken,
+  context: DetectionContext,
+  training: TrainingDatabase | null,
+): DetectionResult {
+  // 1. Check training corrections first (highest priority)
+  if (training && training.examples.length > 0) {
+    const trainedResult = checkTrainingRules(token, context, training);
+    if (trainedResult) return trainedResult;
+  }
+
+  // 2. Pattern-based detection
+  switch (token.type) {
+    case 'table':
+      return detectTableType(token, context);
+    case 'blockquote':
+      return { block_type: 'callout', confidence: 0.85 };
+    case 'list':
+      return detectListType(token, context);
+    case 'paragraph':
+      return detectParagraphType(token, context);
+    case 'heading':
+      // Headings below H2 are absorbed into prose blocks
+      return { block_type: 'prose', confidence: 0.9 };
+    default:
+      return { block_type: 'prose', confidence: 0.7 };
+  }
+}
+
+function detectTableType(token: MarkdownToken, context: DetectionContext): DetectionResult {
+  const table = parseTable(token.content);
+
+  // Check if this is an encounter stats table
+  if (isEncounterTable(table.headers)) {
+    return { block_type: 'encounter', confidence: 0.9 };
+  }
+
+  // Check if the heading above suggests an encounter
+  if (context.heading_above && ENCOUNTER_HEADING_PATTERNS.some(p => p.test(context.heading_above!))) {
+    return { block_type: 'encounter', confidence: 0.8 };
+  }
+
+  return { block_type: 'table', confidence: 0.85 };
+}
+
+function detectListType(token: MarkdownToken, _context: DetectionContext): DetectionResult {
+  if (looksLikeChecklist(token.content)) {
+    return { block_type: 'checklist', confidence: 0.75 };
+  }
+  return { block_type: 'prose', confidence: 0.7 };
+}
+
+function detectParagraphType(token: MarkdownToken, context: DetectionContext): DetectionResult {
+  // Check for callout patterns
+  if (CALLOUT_PATTERNS.some(p => p.test(token.content))) {
+    return { block_type: 'callout', confidence: 0.85 };
+  }
+
+  // Check for event patterns (bonding events, missable conversations, etc.)
+  // — checked before quest patterns because "missable side quest" should still
+  //   classify as quest, but a "bonding event" heading should win.
+  if (context.heading_above && EVENT_HEADING_PATTERNS.some(p => p.test(context.heading_above!))) {
+    return { block_type: 'event', confidence: 0.85 };
+  }
+  if (EVENT_BODY_PATTERNS.some(p => p.test(token.content))) {
+    return { block_type: 'event', confidence: 0.75 };
+  }
+
+  // Check for quest patterns
+  if (QUEST_PATTERNS.some(p => p.test(token.content))) {
+    return { block_type: 'quest', confidence: 0.75 };
+  }
+
+  // Check heading context for encounter
+  if (context.heading_above && ENCOUNTER_HEADING_PATTERNS.some(p => p.test(context.heading_above!))) {
+    return { block_type: 'encounter', confidence: 0.7 };
+  }
+
+  return { block_type: 'prose', confidence: 0.9 };
+}
+
+function checkTrainingRules(
+  token: MarkdownToken,
+  context: DetectionContext,
+  training: TrainingDatabase,
+): DetectionResult | null {
+  // Find matching examples by context similarity
+  const matches = training.examples.filter(ex => {
+    if (context.heading_above && ex.context.heading_above) {
+      return ENCOUNTER_HEADING_PATTERNS.some(p =>
+        p.test(context.heading_above!) && p.test(ex.context.heading_above!)
+      );
+    }
+    // Match by source pattern substring
+    return token.content.includes(ex.source_pattern.slice(0, 50));
+  });
+
+  if (matches.length > 0) {
+    // Use the most common correction
+    const corrections = matches.map(m => m.user_corrected_to);
+    const mostCommon = mode(corrections);
+    return { block_type: mostCommon, confidence: 0.85 + (matches.length * 0.02) };
+  }
+
+  return null;
+}
+
+function mode(arr: BlockType[]): BlockType {
+  const counts = new Map<BlockType, number>();
+  for (const item of arr) {
+    counts.set(item, (counts.get(item) || 0) + 1);
+  }
+  let max = 0;
+  let result: BlockType = 'prose';
+  for (const [key, count] of counts) {
+    if (count > max) {
+      max = count;
+      result = key;
+    }
+  }
+  return result;
+}
+
+// ── Block construction ──────────────────────────────────────────────────────
+
+export function buildBlock(token: MarkdownToken, blockType: BlockType, context: DetectionContext): WalkthroughBlock {
+  switch (blockType) {
+    case 'prose':
+      return {
+        type: 'prose',
+        heading: context.heading_above,
+        content: token.content,
+      };
+
+    case 'encounter': {
+      const name = extractEncounterName(token, context);
+      if (token.type === 'table') {
+        const table = parseTable(token.content);
+        const stats: Record<string, string> = {};
+        if (table.rows.length > 0) {
+          table.headers.forEach((h, i) => {
+            if (table.rows[0][i]) stats[h] = table.rows[0][i];
+          });
+        }
+        return { type: 'encounter', heading: context.heading_above, name, stats };
+      }
+      return { type: 'encounter', heading: context.heading_above, name, strategy: token.content };
+    }
+
+    case 'quest': {
+      const questName = extractQuestName(token, context);
+      return {
+        type: 'quest',
+        heading: context.heading_above,
+        quest_type: detectQuestType(token.content, context),
+        name: questName,
+        content: token.content,
+        missable_window: extractMissableWindow(token.content),
+      };
+    }
+
+    case 'event': {
+      return {
+        type: 'event',
+        heading: context.heading_above,
+        event_type: detectEventType(token.content, context),
+        name: extractEventName(token, context),
+        trigger: extractEventTrigger(token.content),
+        availability: extractMissableWindow(token.content),
+        missable: MISSABLE_KEYWORDS.test(token.content) ||
+                  (context.heading_above ? /missable/i.test(context.heading_above) : false),
+        content: token.content,
+      };
+    }
+
+    case 'table': {
+      const table = parseTable(token.content);
+      return {
+        type: 'table',
+        heading: context.heading_above,
+        columns: table.headers,
+        rows: table.rows,
+      };
+    }
+
+    case 'checklist': {
+      const items = parseChecklistItems(token.content);
+      return { type: 'checklist', heading: context.heading_above, items };
+    }
+
+    case 'callout':
+      return {
+        type: 'callout',
+        severity: detectCalloutSeverity(token.content),
+        content: token.content.replace(/^(warning|note|important|caution|tip)[\s:!]*/i, ''),
+      };
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function extractEncounterName(token: MarkdownToken, context: DetectionContext): string {
+  if (context.heading_above) {
+    const match = context.heading_above.match(/boss:\s*(.+)/i) ||
+                  context.heading_above.match(/battle:\s*(.+)/i) ||
+                  context.heading_above.match(/encounter:\s*(.+)/i);
+    if (match) return match[1].trim();
+    return context.heading_above;
+  }
+  return 'Unknown Encounter';
+}
+
+function extractQuestName(token: MarkdownToken, context: DetectionContext): string {
+  const match = token.content.match(/(?:quest|side quest):\s*(.+)/i);
+  if (match) return match[1].trim();
+  if (context.heading_above) return context.heading_above;
+  return 'Unknown Quest';
+}
+
+function detectQuestType(
+  content: string,
+  context: DetectionContext,
+): 'main' | 'side' | 'missable' | 'hidden' | 'story' {
+  const haystack = `${context.heading_above ?? ''}\n${content}`;
+  // Missable check first — a "missable side quest" is more useful tagged as missable.
+  if (/missable\s+(?:side\s+)?quest/i.test(haystack) ||
+      (/side quest/i.test(haystack) && MISSABLE_KEYWORDS.test(content))) {
+    return 'missable';
+  }
+  if (/hidden quest/i.test(haystack)) return 'hidden';
+  if (/side quest/i.test(haystack)) return 'side';
+  if (/main quest/i.test(haystack)) return 'main';
+  return 'story';
+}
+
+function detectEventType(
+  content: string,
+  context: DetectionContext,
+): 'bonding' | 'conversation' | 'cutscene' | 'collectible' | 'other' {
+  const haystack = `${context.heading_above ?? ''}\n${content}`;
+  if (/bond(?:ing)? event/i.test(haystack)) return 'bonding';
+  if (/conversation|dialogue|talk to/i.test(haystack)) return 'conversation';
+  if (/cutscene|scene/i.test(haystack)) return 'cutscene';
+  if (/chest|pickup|collectible|item/i.test(haystack)) return 'collectible';
+  return 'other';
+}
+
+function extractEventName(token: MarkdownToken, context: DetectionContext): string {
+  if (context.heading_above) {
+    // Strip common prefixes like "Bonding Event: " to leave the name.
+    return context.heading_above
+      .replace(/^(bonding event|bond event|optional event|missable event|conversation):\s*/i, '')
+      .trim();
+  }
+  const match = token.content.match(/(?:bonding event|conversation|cutscene):\s*(.+)/i);
+  if (match) return match[1].trim();
+  return 'Unknown Event';
+}
+
+function extractEventTrigger(content: string): string | undefined {
+  // "Trigger: X" or "Talk to X at Y"
+  const trigger = content.match(/trigger:\s*(.+?)(?:\n|$)/i);
+  if (trigger) return trigger[1].trim();
+  const talkTo = content.match(/[Tt]alk to\s+([A-Z][^.\n]{2,80})/);
+  if (talkTo) return talkTo[1].trim();
+  return undefined;
+}
+
+function extractMissableWindow(content: string): string | undefined {
+  // "Available during Chapter 1" / "Only available on Day 2" / "Before X event"
+  const patterns = [
+    /only available (?:during|on|in)\s+([^.\n]+)/i,
+    /available (?:during|on|in)\s+([^.\n]+)/i,
+    /before\s+(?:the\s+)?([^.\n]+?)\s+(?:event|battle|cutscene|ends?)/i,
+    /must be done (?:by|before|during)\s+([^.\n]+)/i,
+    /(?:missable|lost|unavailable)\s+(?:if|once|when|after)\s+(?:you\s+)?([^.\n]+)/i,
+  ];
+  for (const p of patterns) {
+    const m = content.match(p);
+    if (m) return m[1].trim();
+  }
+  return undefined;
+}
+
+function detectCalloutSeverity(content: string): 'info' | 'warning' | 'danger' {
+  if (/danger|critical/i.test(content)) return 'danger';
+  if (/warning|caution/i.test(content)) return 'warning';
+  return 'info';
+}
+
+function parseChecklistItems(content: string): Array<{ id: string; label: string; detail?: string }> {
+  const lines = content.split('\n').filter(l => /^\s*[-*+]\s/.test(l) || /^\s*\d+\.\s/.test(l));
+  return lines.map((line, i) => {
+    const text = line.replace(/^\s*[-*+]\s+/, '').replace(/^\s*\d+\.\s+/, '').trim();
+    const dashSplit = text.split(' — ');
+    return {
+      id: `item-${i + 1}`,
+      label: dashSplit[0].trim(),
+      detail: dashSplit[1]?.trim(),
+    };
+  });
+}

--- a/tools/intake/src/converter/index.ts
+++ b/tools/intake/src/converter/index.ts
@@ -1,0 +1,71 @@
+/**
+ * Main converter orchestrator.
+ * Transforms captured markdown pages into classified walkthrough sections.
+ */
+
+import { parseMarkdown } from './markdown-parser.js';
+import { detectSections } from './detect-sections.js';
+import { detectBlockType, buildBlock } from './detect-blocks.js';
+import { detectCheckpoints } from './detect-checkpoints.js';
+import { ConvertedSection, ClassifiedBlock, TrainingDatabase, BlockType } from '../types.js';
+
+export interface ConvertOptions {
+  training: TrainingDatabase | null;
+  source_site?: string;
+}
+
+export function convertPages(pages: string[], options: ConvertOptions): ConvertedSection[] {
+  // Combine all pages into one markdown document
+  const combined = pages.join('\n\n---\n\n');
+  const tokens = parseMarkdown(combined);
+  const rawSections = detectSections(tokens);
+
+  return rawSections.map(section => {
+    const blocks: ClassifiedBlock[] = [];
+    let headingAbove: string | undefined;
+    let headingLevel: number | undefined;
+    const surroundingTypes: BlockType[] = [];
+
+    for (const token of section.tokens) {
+      // Track heading context
+      if (token.type === 'heading') {
+        headingAbove = token.content;
+        headingLevel = token.level;
+        continue; // Headings become context, not blocks
+      }
+
+      const context = {
+        heading_above: headingAbove,
+        heading_level: headingLevel,
+        surrounding_types: [...surroundingTypes],
+        source_site: options.source_site,
+      };
+
+      const { block_type, confidence } = detectBlockType(token, context, options.training);
+      const block = buildBlock(token, block_type, context);
+
+      blocks.push({
+        block,
+        confidence,
+        source_line_start: token.line_start,
+        source_line_end: token.line_end,
+        approved: false,
+      });
+
+      surroundingTypes.push(block_type);
+      // Reset heading context after it's been used
+      headingAbove = undefined;
+      headingLevel = undefined;
+    }
+
+    const checkpoints = detectCheckpoints(section.tokens, section.id);
+
+    return {
+      id: section.id,
+      title: section.title,
+      blocks,
+      checkpoints,
+      approved: false,
+    };
+  });
+}

--- a/tools/intake/tests/converter/detect-blocks.test.ts
+++ b/tools/intake/tests/converter/detect-blocks.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest';
+import { detectBlockType, buildBlock } from '../../src/converter/detect-blocks.js';
+import { MarkdownToken } from '../../src/converter/markdown-parser.js';
+
+const makeToken = (overrides: Partial<MarkdownToken>): MarkdownToken => ({
+  type: 'paragraph',
+  content: 'Default content',
+  line_start: 0,
+  line_end: 0,
+  ...overrides,
+});
+
+const defaultContext = { surrounding_types: [] as any[] };
+
+describe('detectBlockType', () => {
+  it('classifies plain paragraphs as prose', () => {
+    const token = makeToken({ content: 'Head north and talk to the guard.' });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('prose');
+    expect(result.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('classifies tables with encounter stats as encounter', () => {
+    const token = makeToken({
+      type: 'table',
+      content: '| Name | HP | Weakness |\n|---|---|---|\n| Ortheim | 12000 | Fire |',
+    });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('encounter');
+  });
+
+  it('classifies tables without encounter stats as table', () => {
+    const token = makeToken({
+      type: 'table',
+      content: '| Item | Price | Location |\n|---|---|---|\n| Potion | 100 | Shop |',
+    });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('table');
+  });
+
+  it('classifies blockquotes as callout', () => {
+    const token = makeToken({ type: 'blockquote', content: 'Be careful here!' });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('callout');
+  });
+
+  it('classifies paragraphs starting with Warning as callout', () => {
+    const token = makeToken({ content: 'Warning: This boss is missable!' });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('callout');
+  });
+
+  it('classifies text with quest patterns as quest', () => {
+    const token = makeToken({ content: 'Side Quest: Find the missing cat' });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('quest');
+  });
+
+  it('uses heading context for encounter detection', () => {
+    const token = makeToken({ content: 'This boss uses fire attacks...' });
+    const context = { heading_above: 'Boss: Flame Dragon', surrounding_types: [] as any[] };
+    const result = detectBlockType(token, context, null);
+    expect(result.block_type).toBe('encounter');
+  });
+
+  it('classifies lists with location items as checklist', () => {
+    const token = makeToken({
+      type: 'list',
+      content: '- Golden Orb (location: north tower)\n- Silver Key (location: basement)\n- Red Gem (location: east wing)',
+    });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('checklist');
+  });
+
+  it('classifies regular lists as prose', () => {
+    const token = makeToken({
+      type: 'list',
+      content: '- Go north\n- Talk to NPC',
+    });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('prose');
+  });
+
+  it('respects training corrections over defaults', () => {
+    const token = makeToken({
+      type: 'table',
+      content: '| Item | Qty |\n|---|---|\n| Herb | 3 |',
+    });
+    const training = {
+      examples: [{
+        source_pattern: '| Item | Qty |',
+        converter_guessed: 'table' as const,
+        user_corrected_to: 'checklist' as const,
+        context: { heading_above: undefined },
+        game: 'test',
+        timestamp: '2026-01-01',
+      }],
+      graduation_status: 'training' as const,
+      walkthroughs_processed: 1,
+    };
+    const result = detectBlockType(token, defaultContext, training);
+    expect(result.block_type).toBe('checklist');
+  });
+});
+
+describe('buildBlock', () => {
+  it('builds a prose block with heading context', () => {
+    const token = makeToken({ content: 'Walk north to the plaza.' });
+    const block = buildBlock(token, 'prose', { heading_above: 'Day 1', surrounding_types: [] });
+    expect(block).toEqual({
+      type: 'prose',
+      heading: 'Day 1',
+      content: 'Walk north to the plaza.',
+    });
+  });
+
+  it('builds an encounter block from stats table', () => {
+    const token = makeToken({
+      type: 'table',
+      content: '| Name | HP | Weakness |\n|---|---|---|\n| Dragon | 9999 | Ice |',
+    });
+    const block = buildBlock(token, 'encounter', { heading_above: 'Boss: Dragon', surrounding_types: [] });
+    expect(block.type).toBe('encounter');
+    expect((block as any).name).toBe('Dragon');
+    expect((block as any).stats).toEqual({ Name: 'Dragon', HP: '9999', Weakness: 'Ice' });
+  });
+
+  it('builds a callout block and strips severity prefix', () => {
+    const token = makeToken({ content: 'Warning: Missable item ahead!' });
+    const block = buildBlock(token, 'callout', defaultContext);
+    expect(block.type).toBe('callout');
+    expect((block as any).severity).toBe('warning');
+    expect((block as any).content).toBe('Missable item ahead!');
+  });
+
+  it('builds a table block from markdown table', () => {
+    const token = makeToken({
+      type: 'table',
+      content: '| Shop | Price |\n|---|---|\n| Potion | 50 |\n| Ether | 100 |',
+    });
+    const block = buildBlock(token, 'table', defaultContext);
+    expect(block.type).toBe('table');
+    expect((block as any).columns).toEqual(['Shop', 'Price']);
+    expect((block as any).rows).toHaveLength(2);
+  });
+
+  it('builds a quest block with detected type', () => {
+    const token = makeToken({ content: 'Side Quest: The Missing Cat' });
+    const block = buildBlock(token, 'quest', { heading_above: 'Optional', surrounding_types: [] });
+    expect(block.type).toBe('quest');
+    expect((block as any).quest_type).toBe('side');
+    expect((block as any).name).toBe('The Missing Cat');
+  });
+
+  it('flags a missable quest when text says missable', () => {
+    const token = makeToken({
+      content: 'Side Quest: Help the merchant. This quest is permanently missable if you leave the area.',
+    });
+    const block = buildBlock(token, 'quest', { heading_above: 'Optional', surrounding_types: [] });
+    expect((block as any).quest_type).toBe('missable');
+    expect((block as any).missable_window).toBeDefined();
+  });
+
+  it('flags a missable quest when explicitly labeled', () => {
+    const token = makeToken({
+      content: 'Missable Quest: The Vanishing Cat. Only available during Chapter 1.',
+    });
+    const block = buildBlock(token, 'quest', defaultContext);
+    expect((block as any).quest_type).toBe('missable');
+    expect((block as any).missable_window).toBe('Chapter 1');
+  });
+
+  it('builds an event block for a Cold Steel bonding event', () => {
+    const token = makeToken({
+      content: 'Talk to Laura at the training hall to start her bonding event. Only available during free time on Day 2.',
+    });
+    const block = buildBlock(token, 'event', {
+      heading_above: 'Bonding Event: Laura',
+      surrounding_types: [],
+    });
+    expect(block.type).toBe('event');
+    expect((block as any).event_type).toBe('bonding');
+    expect((block as any).name).toBe('Laura');
+    expect((block as any).missable).toBe(true);
+    expect((block as any).trigger).toContain('Laura');
+    expect((block as any).availability).toBe('free time on Day 2');
+  });
+
+  it('marks non-missable events as missable:false', () => {
+    const token = makeToken({
+      content: 'A scripted cutscene plays when you enter the throne room.',
+    });
+    const block = buildBlock(token, 'event', {
+      heading_above: 'Cutscene: Throne Room',
+      surrounding_types: [],
+    });
+    expect(block.type).toBe('event');
+    expect((block as any).event_type).toBe('cutscene');
+    expect((block as any).missable).toBe(false);
+  });
+});
+
+describe('detectBlockType — events and missables', () => {
+  it('classifies bonding event headings as event', () => {
+    const token = makeToken({ content: 'Talk to Laura at the training hall.' });
+    const result = detectBlockType(token, {
+      heading_above: 'Bonding Event: Laura',
+      surrounding_types: [],
+    }, null);
+    expect(result.block_type).toBe('event');
+  });
+
+  it('classifies text mentioning missable conversation as event', () => {
+    const token = makeToken({
+      content: 'There is a one-time conversation with the merchant only available during Chapter 2.',
+    });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('event');
+  });
+
+  it('classifies missable side quest text as quest (not event)', () => {
+    const token = makeToken({
+      content: 'Side Quest: The Lost Sword. This quest is missable after Chapter 3.',
+    });
+    const result = detectBlockType(token, defaultContext, null);
+    expect(result.block_type).toBe('quest');
+  });
+
+  it('builds a checklist from list items', () => {
+    const token = makeToken({
+      type: 'list',
+      content: '- Red Orb — North Tower\n- Blue Key — Basement',
+    });
+    const block = buildBlock(token, 'checklist', defaultContext);
+    expect(block.type).toBe('checklist');
+    expect((block as any).items).toHaveLength(2);
+    expect((block as any).items[0].label).toBe('Red Orb');
+    expect((block as any).items[0].detail).toBe('North Tower');
+  });
+});


### PR DESCRIPTION
Implements PR 3 of the Walkthrough Intake System proposal — classifies markdown tokens into the seven walkthrough block types and adds the top-level `convertPages` orchestrator that ties parser ▸ sections ▸ blocks ▸ checkpoints together.

## Files added
- `tools/intake/src/converter/detect-blocks.ts` — rule-based classifier with confidence scoring; checks training corrections first, then pattern detection for tables, blockquotes, lists, and paragraphs
- `tools/intake/src/converter/index.ts` — `convertPages(pages, options)` orchestrator returning `ConvertedSection[]`
- `tools/intake/tests/converter/detect-blocks.test.ts` — 23 tests covering all seven block types, heading context, training overrides, and the missable-quest / bonding-event edge cases

## Verification
- `npx tsc --noEmit` — zero errors
- `npm test` — 65 tests pass (42 from prior PRs + 23 new)
- All 7 block types exercised: prose, encounter, quest, event, table, checklist, callout
- Missable-quest + bonding-event detection passes
- Training-override test uses a hand-built `TrainingDatabase` literal — does not import `RulesDB`, so this PR has no value-level dependency on PR 4

## Dependencies
Depends only on PRs 1 + 2 (types + parser + sections + checkpoints). Independent of PR 4 at the value level (uses only the `TrainingDatabase` type from PR 1).

Next unblocked: PR 5 (intake server) — needs PRs 1, 3, 4.