### PR TITLE
Intake PR 6 — CLI

### DIFF
--- a/tools/intake/src/cli.ts
+++ b/tools/intake/src/cli.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Intake CLI — entry point for the walkthrough intake system.
+ * Commands: start, convert, review, finalize
+ */
+
+import { Command } from 'commander';
+import { createServer } from './server.js';
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import slugify from 'slugify';
+import { IntakeSession } from './types.js';
+
+const program = new Command();
+
+program
+  .name('intake')
+  .description('Walkthrough intake system — capture, convert, review, finalize')
+  .version('1.0.0');
+
+program
+  .command('start')
+  .description('Start an intake session for a new walkthrough')
+  .requiredOption('--game <name>', 'Game title')
+  .requiredOption('--source <url>', 'Source walkthrough URL')
+  .option('--port <number>', 'Server port', '3847')
+  .action(async (opts) => {
+    const slug = slugify(opts.game, { lower: true, strict: true });
+    const walkthroughDir = join(process.cwd(), 'walkthroughs', slug);
+    const intakeDir = join(walkthroughDir, '.intake');
+
+    mkdirSync(join(intakeDir, 'pages'), { recursive: true });
+
+    const session: IntakeSession = {
+      game: opts.game,
+      slug,
+      source_url: opts.source,
+      pages_captured: 0,
+      state: 'capturing',
+      created_at: new Date().toISOString(),
+    };
+
+    writeFileSync(join(intakeDir, 'session.json'), JSON.stringify(session, null, 2));
+
+    const app = createServer(walkthroughDir);
+    const port = parseInt(opts.port, 10);
+
+    app.listen(port, () => {
+      console.log(`\n✓ Intake server running on http://localhost:${port}`);
+      console.log(`  Game: ${opts.game}`);
+      console.log(`  Source: ${opts.source}`);
+      console.log(`  Working dir: ${intakeDir}`);
+      console.log(`\n  Open the walkthrough in your browser and use the extension to capture pages.`);
+      console.log(`  Press Ctrl+C to stop.\n`);
+    });
+  });
+
+program
+  .command('convert')
+  .description('Run the deterministic converter on captured pages')
+  .option('--dir <path>', 'Walkthrough directory')
+  .action(async (opts) => {
+    const dir = opts.dir || process.cwd();
+    console.log(`Converting pages in ${dir}...`);
+    // Conversion is triggered via the API — this is a convenience wrapper
+    const response = await fetch(`http://localhost:3847/api/convert`, { method: 'POST' });
+    const result = await response.json();
+    if (result.success) {
+      console.log(`✓ Converted into ${result.sections} sections (${result.total_blocks} blocks)`);
+    } else {
+      console.error(`✗ Conversion failed: ${result.error}`);
+    }
+  });
+
+program
+  .command('finalize')
+  .description('Write approved sections to main-walkthrough.json')
+  .action(async () => {
+    const response = await fetch(`http://localhost:3847/api/finalize`, { method: 'POST' });
+    const result = await response.json();
+    if (result.success) {
+      console.log(`✓ Walkthrough finalized: ${result.output}`);
+    } else {
+      console.error(`✗ Finalize failed: ${result.error}`);
+    }
+  });
+
+// ── Training mode controls ────────────────────────────────────────────────
+// All three commands let you tune the graduation threshold (default 10).
+// Examples:
+//   npx intake set-threshold 50         # bump to 50 walkthroughs
+//   npx intake set-threshold 100        # bump to 100 walkthroughs
+//   INTAKE_GRADUATION_THRESHOLD=25 npx intake training-status   # one-off
+//   npx intake graduate --force         # graduate now regardless of count
+
+program
+  .command('set-threshold <count>')
+  .description('Set how many walkthroughs must be processed before graduation (persisted)')
+  .action(async (count: string) => {
+    const { RulesDB } = await import('./training/rules-db.js');
+    const dbPath = resolveTrainingDbPath();
+    const db = new RulesDB(dbPath);
+    const value = parseInt(count, 10);
+    db.setGraduationThreshold(value);
+    console.log(`✓ Graduation threshold set to ${value} walkthroughs`);
+    console.log(`  Progress: ${db.data.walkthroughs_processed}/${value}`);
+  });
+
+program
+  .command('training-status')
+  .description('Show training mode status and graduation progress')
+  .action(async () => {
+    const { RulesDB } = await import('./training/rules-db.js');
+    const db = new RulesDB(resolveTrainingDbPath());
+    const threshold = db.graduationThreshold;
+    const processed = db.data.walkthroughs_processed;
+    console.log(`Status:     ${db.data.graduation_status}`);
+    console.log(`Threshold:  ${threshold} walkthroughs`);
+    console.log(`Processed:  ${processed} (${Math.min(100, Math.round((processed / threshold) * 100))}%)`);
+    console.log(`Examples:   ${db.data.examples.length} corrections recorded`);
+    if (db.shouldGraduate) {
+      console.log(`\n→ Ready to graduate! Run: npx intake graduate`);
+    }
+  });
+
+program
+  .command('graduate')
+  .description('Graduate out of training mode (auto-approves high-confidence blocks)')
+  .option('--force', 'Graduate even if the threshold has not been reached')
+  .action(async (opts) => {
+    const { RulesDB } = await import('./training/rules-db.js');
+    const db = new RulesDB(resolveTrainingDbPath());
+    if (!db.shouldGraduate && !opts.force) {
+      console.error(
+        `✗ Not eligible to graduate yet (${db.data.walkthroughs_processed}/${db.graduationThreshold}). ` +
+        `Use --force to override.`,
+      );
+      process.exit(1);
+    }
+    db.graduate();
+    console.log(`✓ Graduated! Converter will now auto-approve high-confidence blocks.`);
+  });
+
+function resolveTrainingDbPath(): string {
+  // Repo-relative location, consistent with server.ts
+  return join(process.cwd(), 'tools', 'intake', 'training-data.json');
+}
+
+program.parse();

--- a/tools/intake/tests/cli.test.ts
+++ b/tools/intake/tests/cli.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const CLI = join(process.cwd(), 'src', 'cli.ts');
+// We use tsx so we don't have to build before testing.
+const RUNNER = ['npx', 'tsx', CLI];
+
+const USE_SHELL = process.platform === 'win32';
+
+/** Wrap args containing spaces in double-quotes for Windows cmd shell. */
+function shellQuote(args: string[]): string[] {
+  if (!USE_SHELL) return args;
+  return args.map(a => (a.includes(' ') ? `"${a}"` : a));
+}
+
+function runCli(args: string[], opts: { cwd?: string; env?: Record<string, string> } = {}) {
+  return spawnSync(RUNNER[0], shellQuote([...RUNNER.slice(1), ...args]), {
+    cwd: opts.cwd ?? process.cwd(),
+    env: { ...process.env, ...opts.env },
+    encoding: 'utf-8',
+    shell: USE_SHELL,
+  });
+}
+
+describe('CLI — argument parsing', () => {
+  it('shows version with --version', () => {
+    const result = runCli(['--version']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/\d+\.\d+\.\d+/);
+  });
+
+  it('shows help with --help', () => {
+    const result = runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('start');
+    expect(result.stdout).toContain('convert');
+    expect(result.stdout).toContain('finalize');
+    expect(result.stdout).toContain('set-threshold');
+    expect(result.stdout).toContain('training-status');
+    expect(result.stdout).toContain('graduate');
+  });
+
+  it('errors when start is missing --game', () => {
+    const result = runCli(['start', '--source', 'https://example.com']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/required option.*game/i);
+  });
+
+  it('errors when start is missing --source', () => {
+    const result = runCli(['start', '--game', 'Test Game']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/required option.*source/i);
+  });
+});
+
+describe('CLI — training threshold commands', () => {
+  let workdir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    workdir = join(tmpdir(), `cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(workdir, 'tools', 'intake'), { recursive: true });
+    dbPath = join(workdir, 'tools', 'intake', 'training-data.json');
+  });
+
+  afterEach(() => {
+    if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it('set-threshold persists value to training-data.json', () => {
+    const result = runCli(['set-threshold', '50'], { cwd: workdir });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('50');
+    expect(existsSync(dbPath)).toBe(true);
+    const db = JSON.parse(readFileSync(dbPath, 'utf-8'));
+    expect(db.graduation_threshold).toBe(50);
+  });
+
+  it('set-threshold supports 100', () => {
+    const result = runCli(['set-threshold', '100'], { cwd: workdir });
+    expect(result.status).toBe(0);
+    const db = JSON.parse(readFileSync(dbPath, 'utf-8'));
+    expect(db.graduation_threshold).toBe(100);
+  });
+
+  it('set-threshold rejects zero / negative', () => {
+    const result = runCli(['set-threshold', '0'], { cwd: workdir });
+    expect(result.status).not.toBe(0);
+  });
+
+  it('training-status reports current configuration', () => {
+    writeFileSync(dbPath, JSON.stringify({
+      examples: [], graduation_status: 'training',
+      walkthroughs_processed: 3, graduation_threshold: 50,
+    }));
+    const result = runCli(['training-status'], { cwd: workdir });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('training');
+    expect(result.stdout).toMatch(/50/);
+    expect(result.stdout).toMatch(/3/);
+  });
+
+  it('training-status reflects INTAKE_GRADUATION_THRESHOLD env var', () => {
+    writeFileSync(dbPath, JSON.stringify({
+      examples: [], graduation_status: 'training',
+      walkthroughs_processed: 0, graduation_threshold: 10,
+    }));
+    const result = runCli(['training-status'], {
+      cwd: workdir,
+      env: { INTAKE_GRADUATION_THRESHOLD: '100' },
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/100/);
+  });
+
+  it('graduate refuses early without --force', () => {
+    writeFileSync(dbPath, JSON.stringify({
+      examples: [], graduation_status: 'training',
+      walkthroughs_processed: 1, graduation_threshold: 50,
+    }));
+    const result = runCli(['graduate'], { cwd: workdir });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/not eligible|force/i);
+    // Status should be unchanged
+    const db = JSON.parse(readFileSync(dbPath, 'utf-8'));
+    expect(db.graduation_status).toBe('training');
+  });
+
+  it('graduate --force overrides the threshold check', () => {
+    writeFileSync(dbPath, JSON.stringify({
+      examples: [], graduation_status: 'training',
+      walkthroughs_processed: 1, graduation_threshold: 50,
+    }));
+    const result = runCli(['graduate', '--force'], { cwd: workdir });
+    expect(result.status).toBe(0);
+    const db = JSON.parse(readFileSync(dbPath, 'utf-8'));
+    expect(db.graduation_status).toBe('graduated');
+  });
+
+  it('graduate succeeds when threshold is met', () => {
+    writeFileSync(dbPath, JSON.stringify({
+      examples: [], graduation_status: 'training',
+      walkthroughs_processed: 50, graduation_threshold: 50,
+    }));
+    const result = runCli(['graduate'], { cwd: workdir });
+    expect(result.status).toBe(0);
+    const db = JSON.parse(readFileSync(dbPath, 'utf-8'));
+    expect(db.graduation_status).toBe('graduated');
+  });
+});
+
+describe('CLI — start command', () => {
+  let workdir: string;
+
+  beforeEach(() => {
+    workdir = join(tmpdir(), `cli-start-${Date.now()}`);
+    mkdirSync(workdir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // On Windows the killed child process may still hold file locks briefly.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        if (existsSync(workdir)) rmSync(workdir, { recursive: true, force: true });
+        return;
+      } catch {
+        await new Promise(r => setTimeout(r, 500));
+      }
+    }
+  });
+
+  it('creates the walkthrough directory and session.json', async () => {
+    // Use a random port and kill the process quickly — we just want to verify
+    // the side effects (directories + session file) happened before the server
+    // started listening.
+    const proc = spawnSync(RUNNER[0],
+      shellQuote([...RUNNER.slice(1), 'start', '--game', 'Test Game', '--source', 'https://example.com', '--port', '0']),
+      { cwd: workdir, encoding: 'utf-8', timeout: 3000, shell: USE_SHELL },
+    );
+    // Process is killed by timeout — we don't care about exit code, only side effects.
+    const sessionPath = join(workdir, 'walkthroughs', 'test-game', '.intake', 'session.json');
+    expect(existsSync(sessionPath)).toBe(true);
+    const session = JSON.parse(readFileSync(sessionPath, 'utf-8'));
+    expect(session.game).toBe('Test Game');
+    expect(session.slug).toBe('test-game');
+    expect(session.state).toBe('capturing');
+  });
+});


### PR DESCRIPTION
Implements PR 6 of the Walkthrough Intake System proposal — the `intake` CLI entry point that ties the server and training database together.

## Files added
- `tools/intake/src/cli.ts` — commander-based CLI registered as the package's `bin`. Commands:
  - `start --game <name> --source <url> [--port 3847]` — creates the walkthrough directory + session file and boots the server
  - `convert` — convenience wrapper that POSTs to `/api/convert`
  - `finalize` — convenience wrapper that POSTs to `/api/finalize`
  - `set-threshold <count>` — persists graduation threshold to `training-data.json`
  - `training-status` — prints current threshold / progress / corrections, respects `INTAKE_GRADUATION_THRESHOLD` env var
  - `graduate [--force]` — graduates out of training mode; refuses early without `--force`
- `tools/intake/tests/cli.test.ts` — 13 subprocess-driven tests covering argument parsing, threshold round-trips, env-var override, and `start` side effects

## Verification
- `npx tsc --noEmit` — zero errors
- `npm test` — 90/90 tests pass across 7 test files

## Dependencies
Depends on PRs 4 + 5. No package.json bump — commander, chalk, inquirer, slugify, and tsx were already added in PR 1.

Next: PR 8 (Cold Steel II end-to-end validation) is the final phase.