### PR TITLE
Fix: declare UTF-8 charset in extension popup

### DIFF
--- a/tools/intake-extension/popup.html
+++ b/tools/intake-extension/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <style>
     body { width: 320px; padding: 16px; font-family: system-ui, sans-serif; font-size: 14px; }
     h2 { margin: 0 0 12px; font-size: 16px; }

--- a/tools/intake-extension/tests/manifest.test.js
+++ b/tools/intake-extension/tests/manifest.test.js
@@ -36,3 +36,13 @@ describe('intake-extension manifest.json', () => {
     expect(cs.run_at).toBe('document_idle');
   });
 });
+
+describe('intake-extension popup.html', () => {
+  const popupHtml = readFileSync(join(__dirname, '..', 'popup.html'), 'utf-8');
+
+  it('declares UTF-8 charset', () => {
+    // Must appear inside <head> so Chrome respects multi-byte characters
+    // (em-dash in "Done — Start Conversion", check mark "✓" in CSS).
+    expect(popupHtml).toMatch(/<meta\s+charset\s*=\s*["']?utf-?8["']?\s*\/?\s*>/i);
+  });
+});


### PR DESCRIPTION
Adds `<meta charset="utf-8">` to `tools/intake-extension/popup.html` so Chrome/Edge don't fall back to Windows-1252, which renders the em-dash in "Done — Start Conversion" and the "✓" check mark as mojibake.

Also adds a regression test in `tests/manifest.test.js` asserting the charset declaration is present.

## Verification
- `cd tools/intake-extension && npm test` — 19/19 pass (18 existing + 1 new)
- Reload extension at `chrome://extensions` after the change; popup renders the em-dash and check marks correctly.